### PR TITLE
Remove duplicates from recent ROMs list

### DIFF
--- a/resources/main.py
+++ b/resources/main.py
@@ -6702,6 +6702,8 @@ class Main:
         # --- Compute ROM recently played list ---
         MAX_RECENT_PLAYED_ROMS = 100
         recent_roms_list = fs_load_Collection_ROMs_JSON(RECENT_PLAYED_FILE_PATH)
+        recent_roms_list = [rom for rom in recent_roms_list
+                            if rom['id'] != recent_rom['id']]                                         
         recent_roms_list.insert(0, recent_rom)
         if len(recent_roms_list) > MAX_RECENT_PLAYED_ROMS:
             log_debug('_command_run_rom() len(recent_roms_list) = {0}'.format(len(recent_roms_list)))


### PR DESCRIPTION
The recent ROMs list shows the last 100 launches. Replace it with the last 100 distinct games, ordered from most to least recent.