### PR TITLE
Handle UNC paths for bat/cmd files

### DIFF
--- a/resources/main.py
+++ b/resources/main.py
@@ -7285,6 +7285,17 @@ class Main:
 
             # >> CMD/BAT files in Windows
             elif app_ext == 'bat' or app_ext == 'BAT':
+                # --- Workaround to run UNC paths in Windows ---
+                # >> Retroarch now support ROMs in UNC paths (Samba remotes)
+                new_exec_list = list(exec_list)
+                for i, _ in enumerate(exec_list):
+                    if exec_list[i][0] == '\\':
+                        new_exec_list[i] = '\\' + exec_list[i]
+                        log_debug('_run_process() (Windows) Before arg #{0} = "{1}"'.format(i, exec_list[i]))
+                        log_debug('_run_process() (Windows) Now    arg #{0} = "{1}"'.format(i, new_exec_list[i]))
+                exec_list = list(new_exec_list)
+                log_debug('_run_process() (Windows) exec_list = {0}'.format(exec_list))
+                
                 log_debug('_run_process() (Windows) Launching BAT application')
                 log_debug('_run_process() (Windows) Ignoring setting windows_cd_apppath')
                 log_debug('_run_process() (Windows) Ignoring setting windows_close_fds')


### PR DESCRIPTION
Fixes UNC paths (samba remotes) passed as arguments to an bat/cmd file.
Without this fix \\ becomes \ in bat/cmd file and rom path becomes invalid.