### PR TITLE
Made filename abstract

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 [B]Advanced Emulator Launcher | version 0.9.9 | XX February 2018[/B]
 
+WIP      Moved FileName to its own file and made it abstract to be able to support
+         xbmcvfs but also just normal os operations in cases you run python script 
+         outside of kodi (like with tools etc.)
+
 WIP      Massive AEL refactoring. Thanks a lot to Chrisism for the patch!
 
 WIP      Complete Extranafart support for Categories/Launchers.

--- a/resources/assets.py
+++ b/resources/assets.py
@@ -510,7 +510,7 @@ def assets_get_path_noext_DIR(Asset, AssetPath, ROM):
 #
 def assets_get_path_noext_SUFIX(Asset, AssetPath, asset_base_noext, objectID = '000'):
     # >> Returns asset/artwork path_noext
-    asset_path_noext_FileName = FileName('')
+    asset_path_noext_FileName = FileNameFactory.create('')
     objectID_str = '_' + objectID[0:3]
 
     if   Asset.kind == ASSET_ICON:       asset_path_noext_FileName = AssetPath.pjoin(asset_base_noext + objectID_str + '_icon')
@@ -620,7 +620,7 @@ def assets_search_local_assets(launcher, ROMFile, enabled_ROM_asset_list):
         if not enabled_ROM_asset_list[i]:
             log_verb('assets_search_local_assets() Disabled {0:<9}'.format(AInfo.name))
             continue
-        asset_path = FileName(launcher[AInfo.path_key])
+        asset_path = FileNameFactory.create(launcher[AInfo.path_key])
         local_asset = misc_look_for_file(asset_path, ROMFile.getBase_noext(), AInfo.exts)
 
         if local_asset:
@@ -641,12 +641,12 @@ def assets_get_ROM_asset_path(launcher):
     ROM_asset_path = ''
     duplicated_bool_list = [False] * len(ROM_ASSET_LIST)
     AInfo_first = assets_get_info_scheme(ROM_ASSET_LIST[0])
-    path_first_asset_FN = FileName(launcher[AInfo_first.path_key])
+    path_first_asset_FN = FileNameFactory.create(launcher[AInfo_first.path_key])
     log_debug('assets_get_ROM_asset_path() path_first_asset OP  "{0}"'.format(path_first_asset_FN.getOriginalPath()))
     log_debug('assets_get_ROM_asset_path() path_first_asset Dir "{0}"'.format(path_first_asset_FN.getDir()))
     for i, asset_kind in enumerate(ROM_ASSET_LIST):
         AInfo = assets_get_info_scheme(asset_kind)
-        current_path_FN = FileName(launcher[AInfo.path_key])
+        current_path_FN = FileNameFactory.create(launcher[AInfo.path_key])
         if current_path_FN.getDir() == path_first_asset_FN.getDir():
             duplicated_bool_list[i] = True
 

--- a/resources/autoconfig.py
+++ b/resources/autoconfig.py
@@ -512,13 +512,13 @@ def autoconfig_import_category(categories, categoryID, i_category, import_FN):
         log_debug('Asset_Prefix_tail      "{0}"'.format(Asset_Prefix_tail))
         if Asset_Prefix_head:
             log_debug('Asset_Prefix head not empty')
-            asset_dir_FN = FileName(import_FN.getDir()).pjoin(Asset_Prefix_head)
-            norm_asset_dir_FN = FileName(os.path.normpath(asset_dir_FN.getPath()))
+            asset_dir_FN = FileNameFactory.create(import_FN.getDir()).pjoin(Asset_Prefix_head)
+            norm_asset_dir_FN = FileNameFactory.create(os.path.normpath(asset_dir_FN.getPath()))
             effective_Asset_Prefix = Asset_Prefix_tail
         else:
             log_debug('Asset_Prefix head is empty. Assets in same dir as XML file')
-            asset_dir_FN = FileName(import_FN.getDir())
-            norm_asset_dir_FN = FileName(os.path.normpath(asset_dir_FN.getPath()))
+            asset_dir_FN = FileNameFactory.create(import_FN.getDir())
+            norm_asset_dir_FN = FileNameFactory.create(os.path.normpath(asset_dir_FN.getPath()))
             effective_Asset_Prefix = Asset_Prefix_tail
         log_debug('import_FN              "{0}"'.format(import_FN.getPath()))
         log_debug('asset_dir_FN           "{0}"'.format(asset_dir_FN.getPath()))
@@ -560,14 +560,14 @@ def autoconfig_import_category(categories, categoryID, i_category, import_FN):
         listitems_list = []
         listitems_asset_paths = []
         # >> Current image if found
-        current_FN = FileName(categories[categoryID][AInfo.key])
+        current_FN = FileNameFactory.create(categories[categoryID][AInfo.key])
         if current_FN.exists():
             asset_listitem = xbmcgui.ListItem(label = 'Current image', label2 = current_FN.getPath())
             asset_listitem.setArt({'icon' : current_FN.getPath()})
             listitems_list.append(asset_listitem)
             listitems_asset_paths.append(current_FN.getPath())
         # >> Image in <s_icon>, <s_fanart>, ... tags if found
-        tag_asset_FN = FileName(i_category[AInfo.key])
+        tag_asset_FN = FileNameFactory.create(i_category[AInfo.key])
         if tag_asset_FN.exists():
             asset_listitem = xbmcgui.ListItem(label = 'XML <{0}> image'.format(AInfo.key),
                                               label2 = tag_asset_FN.getPath())
@@ -578,7 +578,7 @@ def autoconfig_import_category(categories, categoryID, i_category, import_FN):
         image_count = 1
         for asset_file_name in asset_file_list:
             log_debug('asset_file_name "{0}"'.format(asset_file_name))
-            asset_FN = FileName(asset_file_name)
+            asset_FN = FileNameFactory.create(asset_file_name)
             asset_listitem = xbmcgui.ListItem(label = '<Asset_Prefix> #{0} "{1}"'.format(image_count, asset_FN.getBase()),
                                               label2 = asset_file_name)
             asset_listitem.setArt({'icon' : asset_file_name})
@@ -625,7 +625,7 @@ def autoconfig_import_launcher(ROMS_DIR, categories, launchers, categoryID, laun
     # >> Process <Launcher_NFO> before any metadata tag
     if i_launcher['Launcher_NFO']:
         log_debug('Imported Launcher_NFO "{0}"'.format(i_launcher['Launcher_NFO']))
-        Launcher_NFO_FN = FileName(import_FN.getDir()).pjoin(i_launcher['Launcher_NFO'])
+        Launcher_NFO_FN = FileNameFactory.create(import_FN.getDir()).pjoin(i_launcher['Launcher_NFO'])
         Launcher_NFO_meta = fs_read_launcher_NFO(Launcher_NFO_FN)
         log_debug('NFO year      "{0}"'.format(Launcher_NFO_meta['year']))
         log_debug('NFO genre     "{0}"'.format(Launcher_NFO_meta['genre']))
@@ -705,7 +705,7 @@ def autoconfig_import_launcher(ROMS_DIR, categories, launchers, categoryID, laun
 
     # >> If application not found warn user.
     if i_launcher['application']:
-        app_FN = FileName(i_launcher['application'])
+        app_FN = FileNameFactory.create(i_launcher['application'])
         if not app_FN.exists():
             log_debug('Application NOT found.')
             kodi_dialog_OK('Application "{0}" not found'.format(app_FN.getPath()),
@@ -729,7 +729,7 @@ def autoconfig_import_launcher(ROMS_DIR, categories, launchers, categoryID, laun
 
     # >> Warn user if rompath directory does not exist
     if i_launcher['ROM_path']:
-        rompath = FileName(i_launcher['ROM_path'])
+        rompath = FileNameFactory.create(i_launcher['ROM_path'])
         log_debug('ROMpath OP "{0}"'.format(rompath.getOriginalPath()))
         log_debug('ROMpath  P "{0}"'.format(rompath.getPath()))
         if not rompath.exists():
@@ -784,7 +784,7 @@ def autoconfig_import_launcher(ROMS_DIR, categories, launchers, categoryID, laun
     if i_launcher['ROM_asset_path']:
         launchers[launcherID]['ROM_asset_path'] = i_launcher['ROM_asset_path']
         log_debug('Imported ROM_asset_path  "{0}"'.format(i_launcher['ROM_asset_path']))
-        ROM_asset_path_FN = FileName(i_launcher['ROM_asset_path'])
+        ROM_asset_path_FN = FileNameFactory.create(i_launcher['ROM_asset_path'])
         log_debug('ROM_asset_path_FN OP "{0}"'.format(ROM_asset_path_FN.getOriginalPath()))
         log_debug('ROM_asset_path_FN  P "{0}"'.format(ROM_asset_path_FN.getPath()))
 
@@ -872,13 +872,13 @@ def autoconfig_import_launcher(ROMS_DIR, categories, launchers, categoryID, laun
         log_debug('Asset_Prefix_tail      "{0}"'.format(Asset_Prefix_tail))
         if Asset_Prefix_head:
             log_debug('Asset_Prefix head not empty')
-            asset_dir_FN = FileName(import_FN.getDir()).pjoin(Asset_Prefix_head)
-            norm_asset_dir_FN = FileName(os.path.normpath(asset_dir_FN.getPath()))
+            asset_dir_FN = FileNameFactory.create(import_FN.getDir()).pjoin(Asset_Prefix_head)
+            norm_asset_dir_FN = FileNameFactory.create(os.path.normpath(asset_dir_FN.getPath()))
             effective_Asset_Prefix = Asset_Prefix_tail
         else:
             log_debug('Asset_Prefix head is empty. Assets in same dir as XML file')
-            asset_dir_FN = FileName(import_FN.getDir())
-            norm_asset_dir_FN = FileName(os.path.normpath(asset_dir_FN.getPath()))
+            asset_dir_FN = FileNameFactory.create(import_FN.getDir())
+            norm_asset_dir_FN = FileNameFactory.create(os.path.normpath(asset_dir_FN.getPath()))
             effective_Asset_Prefix = Asset_Prefix_tail
         log_debug('import_FN              "{0}"'.format(import_FN.getPath()))
         log_debug('asset_dir_FN           "{0}"'.format(asset_dir_FN.getPath()))
@@ -911,7 +911,7 @@ def autoconfig_import_launcher(ROMS_DIR, categories, launchers, categoryID, laun
         listitems_list = []
         listitems_asset_paths = []
         # >> Current image if found
-        current_FN = FileName(launchers[launcherID][AInfo.key])
+        current_FN = FileNameFactory.create(launchers[launcherID][AInfo.key])
         if current_FN.exists():
             log_debug('Current asset found "{0}"'.format(current_FN.getPath()))
             asset_listitem = xbmcgui.ListItem(label = 'Current image', label2 = current_FN.getPath())
@@ -921,7 +921,7 @@ def autoconfig_import_launcher(ROMS_DIR, categories, launchers, categoryID, laun
         else:
             log_debug('Current asset NOT found "{0}"'.format(current_FN.getPath()))
         # >> Image in <s_icon>, <s_fanart>, ... tags if found
-        tag_asset_FN = FileName(i_launcher[AInfo.key])
+        tag_asset_FN = FileNameFactory.create(i_launcher[AInfo.key])
         if tag_asset_FN.exists():
             log_debug('<{0}> tag found "{1}"'.format(AInfo.key, tag_asset_FN.getPath()))
             asset_listitem = xbmcgui.ListItem(label = 'XML <{0}> image'.format(AInfo.key),
@@ -935,7 +935,7 @@ def autoconfig_import_launcher(ROMS_DIR, categories, launchers, categoryID, laun
         image_count = 1
         for asset_file_name in asset_file_list:
             log_debug('Asset_Prefix found "{0}"'.format(asset_file_name))
-            asset_FN = FileName(asset_file_name)
+            asset_FN = FileNameFactory.create(asset_file_name)
             asset_listitem = xbmcgui.ListItem(label = '<Asset_Prefix> #{0} "{1}"'.format(image_count, asset_FN.getBase()),
                                               label2 = asset_file_name)
             asset_listitem.setArt({'icon' : asset_file_name})

--- a/resources/disk_IO.py
+++ b/resources/disk_IO.py
@@ -1113,7 +1113,7 @@ def fs_export_ROM_collection_assets(output_FileName, collection, collection_rom_
     log_debug('fs_export_ROM_collection_assets() Exporting Collecion assets')
     for asset_kind in CATEGORY_ASSET_LIST:
         AInfo    = assets_get_info_scheme(asset_kind)
-        asset_FN = FileName(collection[AInfo.key])
+        asset_FN = FileNameFactory.create(collection[AInfo.key])
         if not collection[AInfo.key]:
             log_debug('{0:<9s} not set'.format(AInfo.name))
             continue
@@ -1141,7 +1141,7 @@ def fs_export_ROM_collection_assets(output_FileName, collection, collection_rom_
         log_debug('fs_export_ROM_collection_assets() ROM "{0}"'.format(rom_item['m_name']))
         for asset_kind in ROM_ASSET_LIST:
             AInfo    = assets_get_info_scheme(asset_kind)
-            asset_FN = FileName(rom_item[AInfo.key])
+            asset_FN = FileNameFactory.create(rom_item[AInfo.key])
             if not rom_item[AInfo.key]:
                 log_debug('{0:<9s} not set'.format(AInfo.name))
                 continue
@@ -1539,7 +1539,7 @@ def fs_load_legacy_AL_launchers(AL_launchers_filepath, categories, launchers):
 def fs_export_ROM_NFO(rom, verbose = True):
     # >> Skip No-Intro Added ROMs. rom['filename'] will be empty.
     if not rom['filename']: return
-    ROMFileName = FileName(rom['filename'])
+    ROMFileName = FileNameFactory.create(rom['filename'])
     nfo_file_path = ROMFileName.switchExtension('.nfo')
     log_debug('fs_export_ROM_NFO() Exporting "{0}"'.format(nfo_file_path.getOriginalPath()))
 
@@ -1580,7 +1580,7 @@ def fs_export_ROM_NFO(rom, verbose = True):
 # About reading files in Unicode http://stackoverflow.com/questions/147741/character-reading-from-file-in-python
 #
 def fs_import_ROM_NFO(roms, romID, verbose = True):
-    ROMFileName = FileName(roms[romID]['filename'])
+    ROMFileName = FileNameFactory.create(roms[romID]['filename'])
     nfo_file_path = ROMFileName.switchExtension('.nfo')
     log_debug('fs_import_ROM_NFO() Loading "{0}"'.format(nfo_file_path.getPath()))
 
@@ -1665,8 +1665,8 @@ def fs_import_ROM_NFO_file_scanner(nfo_file_path):
 # Returns a FileName object
 #
 def fs_get_ROM_NFO_name(rom):
-    ROMFileName = FileName(rom['filename'])
-    nfo_file_path = FileName(ROMFileName.getPath_noext() + '.nfo')
+    ROMFileName = FileNameFactory.create(rom['filename'])
+    nfo_file_path = FileNameFactory.create(ROMFileName.getPath_noext() + '.nfo')
     log_debug("fs_get_ROM_NFO_name() nfo_file_path = '{0}'".format(nfo_file_path.getOriginalPath()))
 
     return nfo_file_path
@@ -1801,7 +1801,7 @@ def fs_read_launcher_NFO(nfo_FileName):
 #
 def fs_get_launcher_NFO_name(settings, launcher):
     launcher_name = launcher['m_name']
-    nfo_dir = FileName(settings['launchers_asset_dir'])
+    nfo_dir = FileNameFactory.create(settings['launchers_asset_dir'])
     nfo_file_path = nfo_dir.pjoin(launcher_name + '.nfo')
     log_debug("fs_get_launcher_NFO_name() nfo_file_path = '{0}'".format(nfo_file_path.getOriginalPath()))
 
@@ -1876,7 +1876,7 @@ def fs_import_category_NFO(nfo_FileName, categories, categoryID):
 #
 def fs_get_category_NFO_name(settings, category):
     category_name = category['m_name']
-    nfo_dir = FileName(settings['categories_asset_dir'])
+    nfo_dir = FileNameFactory.create(settings['categories_asset_dir'])
     nfo_file_path = nfo_dir.pjoin(category_name + '.nfo')
     log_debug("fs_get_category_NFO_name() nfo_file_path = '{0}'".format(nfo_file_path.getOriginalPath()))
 
@@ -1941,7 +1941,7 @@ def fs_import_collection_NFO(nfo_FileName, collections, launcherID):
 
 def fs_get_collection_NFO_name(settings, collection):
     collection_name = collection['m_name']
-    nfo_dir = FileName(settings['collections_asset_dir'])
+    nfo_dir = FileNameFactory.create(settings['collections_asset_dir'])
     nfo_file_path = nfo_dir.pjoin(collection_name + '.nfo')
     log_debug("fs_get_collection_NFO_name() nfo_file_path = '{0}'".format(nfo_file_path.getOriginalPath()))
 

--- a/resources/executors.py
+++ b/resources/executors.py
@@ -20,7 +20,7 @@ class ExecutorFactory():
         self.logFile = logFile
 
     def create_from_pathstring(self, application_string):
-        app = FileName(application_string)
+        app = FileNameFactory.create(application_string)
         return self.create(app)
 
     def create(self, application):

--- a/resources/filename.py
+++ b/resources/filename.py
@@ -1,0 +1,537 @@
+# -*- coding: utf-8 -*-
+#
+# Advanced Emulator Launcher
+# Copyright (c) 2016-2018 Wintermute0110 <wintermute0110@gmail.com>
+# Portions (c) 2010-2015 Angelscry and others
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# -------------------------------------------------------------------------------------------------
+# Utility functions which DEPEND on Kodi modules
+# -------------------------------------------------------------------------------------------------
+# --- Python compiler flags ---
+from __future__ import unicode_literals
+
+# --- Python standard library ---
+from abc import ABCMeta, abstractmethod
+
+import sys, os, shutil, urlparse, json, fnmatch
+import xml.etree.ElementTree as ET
+
+# --- Kodi modules ---
+try:
+    import xbmc, xbmcvfs
+except:
+    from utils_kodi_standalone import *
+
+# -------------------------------------------------------------------------------------------------
+# Factory for creating new FileName instances.
+# Can either create a FileName base on xmbcvfs or just normal os operations.
+# -------------------------------------------------------------------------------------------------
+class FileNameFactory():
+
+    @staticmethod
+    def create(pathString, no_xbmcvfs = False):
+
+        if no_xbmcvfs:
+            return StandardFileName(pathString)
+        
+        return KodiFileName(pathString)
+
+# -------------------------------------------------------------------------------------------------
+# Filesystem abstract base class
+# This class and classes that inherit this one always take and return Unicode string paths.
+# Decoding Unicode to UTF-8 or whatever must be done in the caller code.
+#
+# IMPROVE THE DOCUMENTATION OF THIS CLASS AND HOW IT HANDLES EXCEPTIONS AND ERROR REPORTING!!!
+#
+# A) Transform paths like smb://server/directory/ into \\server\directory\
+# B) Use xbmc.translatePath() for paths starting with special://
+# C) Uses xbmcvfs wherever possible
+#
+# -------------------------------------------------------------------------------------------------
+class FileName():
+    __metaclass__ = ABCMeta
+
+    # pathString must be a Unicode string object
+    def __init__(self, pathString):
+        self.originalPath = pathString
+        self.path         = pathString
+        
+        # --- Path transformation ---
+        if self.originalPath.lower().startswith('smb:'):
+            self.path = self.path.replace('smb:', '')
+            self.path = self.path.replace('SMB:', '')
+            self.path = self.path.replace('//', '\\\\')
+            self.path = self.path.replace('/', '\\')
+
+        elif self.originalPath.lower().startswith('special:'):
+            self.path = xbmc.translatePath(self.path)
+
+    # abstract protected method, to be implemented in child classes.
+    # Will return a new instance of the desired child implementation.
+    @abstractmethod
+    def __create__(self, pathString):
+        return FileName(pathString)
+
+    def _join_raw(self, arg):
+        self.path         = os.path.join(self.path, arg)
+        self.originalPath = os.path.join(self.originalPath, arg)
+
+        return self
+
+    # Appends a string to path. Returns self FileName object
+    def append(self, arg):
+        self.path         = self.path + arg
+        self.originalPath = self.originalPath + arg
+
+        return self
+
+    # >> Joins paths. Returns a new FileName object
+    def pjoin(self, *args):
+        child = self.__create__(self.originalPath)
+        for arg in args:
+            child._join_raw(arg)
+
+        return child
+
+    # Behaves like os.path.join()
+    #
+    # See http://blog.teamtreehouse.com/operator-overloading-python
+    # other is a FileName object. other originalPath is expected to be a subdirectory (path
+    # transformation not required)
+    def __add__(self, other):
+        current_path = self.originalPath
+        if type(other) is FileName:  other_path = other.originalPath
+        elif type(other) is unicode: other_path = other
+        elif type(other) is str:     other_path = other.decode('utf-8')
+        else: raise NameError('Unknown type for overloaded + in FileName object')
+        new_path = os.path.join(current_path, other_path)
+        child    = self.__create__(new_path)
+
+        return child
+        
+    def escapeQuotes(self):
+        self.path = self.path.replace("'", "\\'")
+        self.path = self.path.replace('"', '\\"')
+
+    # ---------------------------------------------------------------------------------------------
+    # Decomposes a file name path or directory into its constituents
+    #   FileName.getOriginalPath()  Full path                                     /home/Wintermute/Sonic.zip
+    #   FileName.getPath()          Full path                                     /home/Wintermute/Sonic.zip
+    #   FileName.getPath_noext()    Full path with no extension                   /home/Wintermute/Sonic
+    #   FileName.getDir()           Directory name of file. Does not end in '/'   /home/Wintermute/
+    #   FileName.getBase()          File name with no path                        Sonic.zip
+    #   FileName.getBase_noext()    File name with no path and no extension       Sonic
+    #   FileName.getExt()           File extension                                .zip
+    # ---------------------------------------------------------------------------------------------
+    def getOriginalPath(self):
+        return self.originalPath
+
+    def getPath(self):
+        return self.path
+
+    def getPath_noext(self):
+        root, ext = os.path.splitext(self.path)
+
+        return root
+
+    def getDir(self):
+        return os.path.dirname(self.path)
+
+    def getDirAsFileName(self):
+        return self.__create__(self.getDir())
+
+    def getBase(self):
+        return os.path.basename(self.path)
+
+    def getBase_noext(self):
+        basename  = os.path.basename(self.path)
+        root, ext = os.path.splitext(basename)
+        
+        return root
+
+    def getExt(self):
+        root, ext = os.path.splitext(self.path)
+        return ext
+
+    def switchExtension(self, targetExt):
+        
+        ext = self.getExt()
+        copiedPath = self.originalPath
+        
+        if not targetExt.startswith('.'):
+            targetExt = '.{0}'.format(targetExt)
+
+        new_path = self.__create__(copiedPath.replace(ext, targetExt))
+        return new_path
+
+    # ---------------------------------------------------------------------------------------------
+    # Scanner functions
+    # ---------------------------------------------------------------------------------------------
+    @abstractmethod
+    def scanFilesInPath(self, mask = '*.*'):
+        return []
+
+    @abstractmethod
+    def scanFilesInPathAsFileNameObjects(self, mask = '*.*'):
+        return []
+    
+    @abstractmethod
+    def recursiveScanFilesInPath(self, mask = '*.*'):
+        return []
+
+    def _decodeName(self, name):
+        if type(name) == str:
+            try:
+                name = name.decode('utf8')
+            except:
+                name = name.decode('windows-1252')
+        
+        return name
+    
+    # ---------------------------------------------------------------------------------------------
+    # Filesystem functions
+    # ---------------------------------------------------------------------------------------------
+    @abstractmethod
+    def stat(self):
+        return None
+    
+    @abstractmethod
+    def exists(self):
+        return None
+    
+    @abstractmethod
+    def isdir(self):
+        return False
+        
+    @abstractmethod
+    def isfile(self):
+        return False
+    
+    @abstractmethod
+    def makedirs(self):
+        pass
+    
+    @abstractmethod
+    def unlink(self):
+        pass
+    
+    @abstractmethod
+    def rename(self, to):
+        pass
+    
+    @abstractmethod
+    def copy(self, to):        
+        pass
+                    
+    # ---------------------------------------------------------------------------------------------
+    # File IO functions
+    # ---------------------------------------------------------------------------------------------
+    
+    @abstractmethod
+    def readAll(self):
+        return None
+    
+    @abstractmethod
+    def readAllUnicode(self, encoding='utf-8'):
+        return None
+    
+    @abstractmethod
+    def writeAll(self, bytes, flags='w'):
+        pass
+    
+    @abstractmethod
+    def write(self, bytes):
+        pass
+       
+    @abstractmethod
+    def open(self, flags):
+        pass
+      
+    @abstractmethod  
+    def close(self):
+        pass
+
+    # Opens file and reads xml. Returns the root of the XML!
+    def readXml(self):
+        data = self.readAll()
+        root = ET.fromstring(data)
+        return root
+
+    # Opens JSON file and reads it
+    def readJson(self):
+        contents = self.readAllUnicode()
+        return json.loads(contents)
+
+    # --- Configure JSON writer ---
+    # NOTE More compact JSON files (less blanks) load faster because size is smaller.
+    def writeJson(self, raw_data, JSON_indent = 1, JSON_separators = (',', ':')):
+        json_data = json.dumps(raw_data, ensure_ascii = False, sort_keys = True, 
+                                indent = JSON_indent, separators = JSON_separators)
+        self.writeAll(unicode(json_data).encode('utf-8'))
+
+# -------------------------------------------------------------------------------------------------
+# Kodi Virtual Filesystem helper class.
+# Implementation of the FileName helper class which supports the xbmcvfs libraries.
+#
+# -------------------------------------------------------------------------------------------------
+class KodiFileName(FileName):
+    
+    def __create__(self, pathString):
+        return KodiFileName(pathString)
+
+    # ---------------------------------------------------------------------------------------------
+    # Scanner functions
+    # ---------------------------------------------------------------------------------------------
+    def scanFilesInPath(self, mask = '*.*'):
+        files = []
+
+        subdirectories, filenames = xbmcvfs.listdir(self.originalPath)
+        for filename in fnmatch.filter(filenames, mask):
+            files.append(os.path.join(self.originalPath, self._decodeName(filename)))
+
+        return files
+
+    def scanFilesInPathAsFileNameObjects(self, mask = '*.*'):
+        files = []
+        
+        subdirectories, filenames = xbmcvfs.listdir(self.originalPath)
+        for filename in fnmatch.filter(filenames, mask):
+            filePath = self.pjoin(self._decodeName(filename))
+            files.append(self.__create__(filePath.getOriginalPath()))
+
+        return files
+
+    def recursiveScanFilesInPath(self, mask = '*.*'):
+        files = []
+        
+        subdirectories, filenames = xbmcvfs.listdir(str(self.originalPath))
+        for filename in fnmatch.filter(filenames, mask):
+            filePath = self.pjoin(self._decodeName(filename))
+            files.append(filePath.getOriginalPath())
+
+        for subdir in subdirectories:
+            subPath = self.pjoin(self._decodeName(subdir))
+            subPathFiles = subPath.recursiveScanFilesInPath(mask)
+            files.extend(subPathFiles)
+
+        return files
+
+    # ---------------------------------------------------------------------------------------------
+    # Filesystem functions
+    # ---------------------------------------------------------------------------------------------
+    def stat(self):
+        return xbmcvfs.Stat(self.originalPath)
+
+    def exists(self):
+        return xbmcvfs.exists(self.originalPath)
+
+    # Warning: not suitable for xbmcvfs paths yet
+    def isdir(self):
+        
+        if not self.exists():
+            return False
+
+        try:
+            self.open('r')
+            self.close()
+        except:
+            return True
+        
+        return False
+        #return os.path.isdir(self.path)
+        
+    # Warning: not suitable for xbmcvfs paths yet
+    def isfile(self):
+
+        if not self.exists():
+            return False
+
+        return not self.isdir()
+        #return os.path.isfile(self.path)
+
+    def makedirs(self):
+        
+        if not self.exists():
+            xbmcvfs.mkdirs(self.originalPath)
+
+    def unlink(self):
+
+        if self.isfile():
+            xbmcvfs.delete(self.originalPath)
+
+            # hard delete if it doesnt succeed
+            log_debug('xbmcvfs.delete() failed, applying hard delete')
+            if self.exists():
+                os.remove(self.path)
+        else:
+            xbmcvfs.rmdir(self.originalPath)
+
+    def rename(self, to):
+
+        if self.isfile():
+            xbmcvfs.rename(self.originalPath, to.getOriginalPath())
+        else:
+            os.rename(self.path, to.getPath())
+
+    def copy(self, to):        
+        xbmcvfs.copy(self.originalPath(), to.getOriginalPath())
+                    
+    # ---------------------------------------------------------------------------------------------
+    # File IO functions
+    # ---------------------------------------------------------------------------------------------
+    
+    def readAll(self):
+        contents = None
+        file = xbmcvfs.File(self.originalPath)
+        contents = file.read()
+        file.close()
+
+        return contents
+    
+    def readAllUnicode(self, encoding='utf-8'):
+        contents = None
+        file = xbmcvfs.File(self.originalPath)
+        contents = file.read()
+        file.close()
+
+        return unicode(contents, encoding)
+    
+    def writeAll(self, bytes, flags='w'):
+        file = xbmcvfs.File(self.originalPath, flags)
+        file.write(bytes)
+        file.close()
+
+    def write(self, bytes):
+       if self.fileHandle is None:
+           raise OSError('file not opened')
+
+       self.fileHandle.write(bytes)
+
+    def open(self, flags):
+        self.fileHandle = xbmcvfs.File(self.originalPath, flags)
+        
+    def close(self):
+        if self.fileHandle is None:
+           raise OSError('file not opened')
+
+        self.fileHandle.close()
+        self.fileHandle = None
+        
+# -------------------------------------------------------------------------------------------------
+# Standard Filesystem helper class.
+# Implementation of the FileName helper class which just uses standard os operations.
+#
+# -------------------------------------------------------------------------------------------------
+class StandardFileName(FileName):
+    
+    def __create__(self, pathString):
+        return StandardFileName(pathString)
+
+    # ---------------------------------------------------------------------------------------------
+    # Scanner functions
+    # ---------------------------------------------------------------------------------------------
+    def scanFilesInPath(self, mask = '*.*'):
+        files = []
+
+        subdirectories, filenames = os.listdir(self.path)
+        for filename in fnmatch.filter(filenames, mask):
+            files.append(os.path.join(self.path, self._decodeName(filename)))
+
+        return files
+
+    def scanFilesInPathAsFileNameObjects(self, mask = '*.*'):
+        files = []
+        
+        subdirectories, filenames = os.listdir(self.path)
+        for filename in fnmatch.filter(filenames, mask):
+            filePath = self.pjoin(self._decodeName(filename))
+            files.append(self.__create__(filePath.getPath()))
+
+        return files
+
+    def recursiveScanFilesInPath(self, mask = '*.*'):
+        files = []
+
+        for root, dirs, foundfiles in os.walk(self.path):
+            for filename in fnmatch.filter(foundfiles, mask):
+                filePath = self.pjoin(self._decodeName(filename))
+                files.append(filePath.getPath())
+
+        return files
+
+    # ---------------------------------------------------------------------------------------------
+    # Filesystem functions
+    # ---------------------------------------------------------------------------------------------
+    def stat(self):
+        return os.stat(self.path)
+
+    def exists(self):
+        return os.path.exists(self.path)
+
+    def isdir(self):
+        return os.path.isdir(self.path)
+        
+    def isfile(self):
+        return os.path.isfile(self.path)
+
+    def makedirs(self):
+        if not os.path.exists(self.path): 
+            os.makedirs(self.path)
+
+    # os.remove() and os.unlink() are exactly the same.
+    def unlink(self):
+        os.unlink(self.path)
+
+    def rename(self, to):
+        os.rename(self.path, to.getPath())
+
+    def copy(self, to):        
+        shutil.copy2(self.getPath(), to.getPath())
+     
+    # ---------------------------------------------------------------------------------------------
+    # File IO functions
+    # ---------------------------------------------------------------------------------------------
+    
+    def readAll(self):
+        contents = None
+        with open(self.path, 'r') as f:
+            contents = f.read()
+        
+        return contents
+    
+    def readAllUnicode(self, encoding='utf-8'):
+        contents = None        
+        with open(self.path, 'r') as f:
+            contents = f.read()
+        
+        return unicode(contents, encoding)
+    
+    def writeAll(self, bytes, flags='w'):
+        with open(self.path, flags) as file:
+            file.write(bytes)
+
+    def write(self, bytes):
+       if self.fileHandle is None:
+           raise OSError('file not opened')
+
+       self.fileHandle.write(bytes)
+
+    def open(self, flags):
+        self.fileHandle = open(self.path, flags)
+        
+    def close(self):
+        if self.fileHandle is None:
+           raise OSError('file not opened')
+
+        self.fileHandle.close()
+        self.fileHandle = None
+

--- a/resources/launcher_builder.py
+++ b/resources/launcher_builder.py
@@ -116,7 +116,7 @@ class launcherBuilder():
         elif launcher_type == LAUNCHER_RETROARCH:
             
             # >> If Retroarch System dir not configured or found abort.
-            sys_dir_FN = FileName(settings['io_retroarch_sys_dir'])
+            sys_dir_FN = FileNameFactory.create(settings['io_retroarch_sys_dir'])
             if not sys_dir_FN.exists():
                 kodi_dialog_OK('Retroarch System directory not found. Please configure it.')
                 return
@@ -165,7 +165,7 @@ class launcherBuilder():
         # B) If this path is the same as the ROM path then asset naming scheme 2 is used.
         # >> Create asset directories. Function detects if we are using naming scheme 1 or 2.
         # >> launcher is edited using Python passing by assignment.
-        assets_init_asset_dir(FileName(launcher['assets_path']), launcher)
+        assets_init_asset_dir(FileNameFactory.create(launcher['assets_path']), launcher)
 
         launchers[launcherID] = launcher
         # >> Notify user
@@ -201,7 +201,7 @@ def getTitleFromAppPath(input, launcher):
         return input
 
     app = launcher['application']
-    appPath = FileName(app)
+    appPath = FileNameFactory.create(app)
 
     title = appPath.getBase_noext()
     title_formatted = title.replace('.' + title.split('.')[-1], '').replace('.', ' ')
@@ -213,7 +213,7 @@ def getExtensionsFromAppPath(input ,launcher):
         return input
 
     app = launcher['application']
-    appPath = FileName(app)
+    appPath = FileNameFactory.create(app)
     
     extensions = emudata_get_program_extensions(appPath.getBase())
     return extensions
@@ -224,7 +224,7 @@ def getArgumentsFromAppPath(input, launcher):
         return input
 
     app = launcher['application']
-    appPath = FileName(app)
+    appPath = FileNameFactory.create(app)
     
     default_arguments = emudata_get_program_arguments(appPath.getBase())
     return default_arguments
@@ -242,7 +242,7 @@ def getValueFromAssetsPath(input, launcher):
     if input:
         return input
 
-    romPath = FileName(launcher['assets_path'])
+    romPath = FileNameFactory.create(launcher['assets_path'])
     romPath = romPath.pjoin('games')
 
     return romPath.getOriginalPath()
@@ -252,7 +252,7 @@ def get_available_retroarch_cores(settings):
     cores = []
     
     if sys.platform == 'win32':
-        retroarchFolder = FileName(settings['io_retroarch_sys_dir'])
+        retroarchFolder = FileNameFactory.create(settings['io_retroarch_sys_dir'])
         retroarchFolder.append('cores\\')
         log_debug("get_available_retroarch_cores() scanning path '{0}'".format(retroarchFolder.getOriginalPath()))
 
@@ -265,7 +265,7 @@ def get_available_retroarch_cores(settings):
             return cores
 
     if sys.platform.startswith('linux'):
-        androidFolder = FileName('/data/com.retroarch/cores/')
+        androidFolder = FileNameFactory.create('/data/com.retroarch/cores/')
         log_debug("get_available_retroarch_cores() scanning path '{0}'".format(androidFolder.getOriginalPath()))
 
         if androidFolder.exists():

--- a/resources/launchers.py
+++ b/resources/launchers.py
@@ -248,7 +248,7 @@ class ApplicationLauncher(Launcher):
     def launch(self):
 
         self.title              = self.launcher['m_name']
-        self.application        = FileName(self.launcher['application'])
+        self.application        = FileNameFactory.create(self.launcher['application'])
         self.arguments          = self.launcher['args']       
         
         # --- Check for errors and abort if errors found ---
@@ -283,9 +283,9 @@ class StandardRomLauncher(Launcher):
 
         if self.rom['altapp']:
             log_info('StandardRomLauncher() Using ROM altapp')
-            self.application = FileName(self.rom['altapp'])
+            self.application = FileNameFactory.create(self.rom['altapp'])
         else:
-            self.application = FileName(self.launcher['application'])
+            self.application = FileNameFactory.create(self.launcher['application'])
 
     def _selectArgumentsToUse(self):
 
@@ -311,7 +311,7 @@ class StandardRomLauncher(Launcher):
     def _selectRomFileToUse(self):
         
         if not 'disks' in self.rom or not self.rom['disks']:
-            return FileName(self.rom['filename'])
+            return FileNameFactory.create(self.rom['filename'])
                 
         log_info('StandardRomLauncher() Multidisc ROM set detected')
         dialog = xbmcgui.Dialog()
@@ -322,8 +322,8 @@ class StandardRomLauncher(Launcher):
         selected_rom_base = self.rom['disks'][dselect_ret]
         log_info('StandardRomLauncher() Selected ROM "{0}"'.format(selected_rom_base))
 
-        ROM_temp = FileName(self.rom['filename'])
-        ROM_dir = FileName(ROM_temp.getDir())
+        ROM_temp = FileNameFactory.create(self.rom['filename'])
+        ROM_dir = FileNameFactory.create(ROM_temp.getDir())
         ROMFileName = ROM_dir.pjoin(selected_rom_base)
 
         return ROMFileName
@@ -435,12 +435,12 @@ class RetroarchLauncher(StandardRomLauncher):
     def _selectApplicationToUse(self):
         
         if sys.platform == 'win32':
-            self.application = FileName(self.settings['io_retroarch_sys_dir'])
+            self.application = FileNameFactory.create(self.settings['io_retroarch_sys_dir'])
             self.application = self.application.append('retroarch.exe')  
             return
 
         if sys.platform.startswith('linux'):
-            self.application = FileName('/system/bin/am')
+            self.application = FileNameFactory.create('/system/bin/am')
             return
 
         #todo other os
@@ -452,8 +452,8 @@ class RetroarchLauncher(StandardRomLauncher):
         retroCore = self.launcher['core']
             
         if sys.platform == 'win32':
-            appPath = FileName(self.settings['io_retroarch_sys_dir'])
-            corePath = appPath.pjoin(FileName('core', retroCore))
+            appPath = FileNameFactory.create(self.settings['io_retroarch_sys_dir'])
+            corePath = appPath.pjoin(FileNameFactory.create('core'), retroCore)
             
             self.arguments = "-L  {0} ".format(corePath.getOriginalPath())
             self.arguments += "'$rom$'"
@@ -488,7 +488,7 @@ class SteamLauncher(Launcher):
         
         url = 'steam://rungameid/'
 
-        self.application = FileName('steam://rungameid/')
+        self.application = FileNameFactory.create('steam://rungameid/')
         self.arguments = str(self.rom['steamid'])
 
         log_info('SteamLauncher() ROM ID {0}: @{1}"'.format(self.rom['steamid'], self.rom['m_name']))

--- a/resources/main.py
+++ b/resources/main.py
@@ -26,6 +26,7 @@ import xbmc, xbmcgui, xbmcplugin, xbmcaddon
 
 # --- Modules/packages in this plugin ---
 from constants import *
+from filename import *
 from utils import *
 from utils_kodi import *
 from utils_kodi_cache import *
@@ -59,11 +60,11 @@ __addon_type__    = __addon_obj__.getAddonInfo('type').decode('utf-8')
 # --- Addon paths and constant definition ---
 # _FILE_PATH is a filename
 # _DIR is a directory (with trailing /)
-ADDONS_DATA_DIR           = FileName('special://profile/addon_data')
+ADDONS_DATA_DIR           = FileNameFactory.create('special://profile/addon_data')
 PLUGIN_DATA_DIR           = ADDONS_DATA_DIR.pjoin(__addon_id__)
-BASE_DIR                  = FileName('special://profile')
-HOME_DIR                  = FileName('special://home')
-KODI_FAV_FILE_PATH        = FileName('special://profile/favourites.xml')
+BASE_DIR                  = FileNameFactory.create('special://profile')
+HOME_DIR                  = FileNameFactory.create('special://home')
+KODI_FAV_FILE_PATH        = FileNameFactory.create('special://profile/favourites.xml')
 ADDONS_DIR                = HOME_DIR.pjoin('addons')
 CURRENT_ADDON_DIR         = ADDONS_DIR.pjoin(__addon_id__)
 ICON_IMG_FILE_PATH        = CURRENT_ADDON_DIR.pjoin('icon.png')
@@ -726,7 +727,7 @@ class Main:
                 NFO_file = xbmcgui.Dialog().browse(1, 'Select NFO description file', 'files', '.nfo', False, False).decode('utf-8')
                 log_debug('_command_edit_category() Dialog().browse returned "{0}"'.format(NFO_file))
                 if not NFO_file: return
-                NFO_FileName = FileName(NFO_file)
+                NFO_FileName = FileNameFactory.create(NFO_file)
                 if not NFO_FileName.exists(): return
                 # >> Returns True if changes were made
                 if not fs_import_category_NFO(NFO_FileName, self.categories, categoryID): return
@@ -910,7 +911,7 @@ class Main:
             if not dir_path: return
 
             # --- If XML exists then warn user about overwriting it ---
-            export_FN = FileName(dir_path).pjoin(category_fn_str)
+            export_FN = FileNameFactory.create(dir_path).pjoin(category_fn_str)
             if export_FN.exists():
                 ret = kodi_dialog_yesno('Overwrite file {0}?'.format(export_FN.getPath()))
                 if not ret:
@@ -1150,7 +1151,7 @@ class Main:
             elif type2 == 8:
                 NFO_file = xbmcgui.Dialog().browse(1, 'Select Launcher NFO file', 'files', '.nfo', False, False).decode('utf-8')
                 if not NFO_file: return
-                NFO_FileName = FileName(NFO_file)
+                NFO_FileName = FileNameFactory.create(NFO_file)
                 if not NFO_FileName.exists(): return
                 # >> Launcher is edited using Python passing by assigment
                 # >> Returns True if changes were made
@@ -1604,7 +1605,7 @@ class Main:
                     for rom_id in roms:
                         # --- Search assets for current ROM ---
                         rom = roms[rom_id]
-                        ROMFile = FileName(rom['filename'])
+                        ROMFile = FileNameFactory.create(rom['filename'])
                         rom_basename_noext = ROMFile.getBase_noext()
                         log_verb('Checking ROM "{0}" (ID {1})'.format(ROMFile.getBase(), rom_id))
 
@@ -1627,16 +1628,16 @@ class Main:
                                 # >> If directory is different it is definitely customised.
                                 # >> If directory is the same and the basename is from a ROM in the
                                 # >> PClone group it is very likely it is substituted.
-                                current_asset_FN = FileName(rom[AInfo.key])
+                                current_asset_FN = FileNameFactory.create(rom[AInfo.key])
                                 if current_asset_FN.exists():
                                     log_debug('Local {0:<9} "{1}"'.format(AInfo.name, current_asset_FN.getPath()))
                                     continue
-                            # >> Old implementation (slow). Using FileName().exists() to check many
+                            # >> Old implementation (slow). Using FileNameFactory.create().exists() to check many
                             # >> files becames really slow.
-                            # asset_dir = FileName(launcher[AInfo.path_key])
+                            # asset_dir = FileNameFactory.create(launcher[AInfo.path_key])
                             # local_asset = misc_look_for_file(asset_dir, rom_basename_noext, AInfo.exts)
                             # >> New implementation using a cache.
-                            asset_path = FileName(launcher[AInfo.path_key])
+                            asset_path = FileNameFactory.create(launcher[AInfo.path_key])
                             local_asset = misc_search_file_cache(asset_path, rom_basename_noext, AInfo.exts)
                             if local_asset:
                                 rom[AInfo.key] = local_asset.getOriginalPath()
@@ -1667,7 +1668,7 @@ class Main:
                         for rom_id in roms:
                             # --- Search assets for current ROM ---
                             rom = roms[rom_id]
-                            ROMFile = FileName(rom['filename'])
+                            ROMFile = FileNameFactory.create(rom['filename'])
                             rom_basename_noext = ROMFile.getBase_noext()
                             log_verb('Checking ROM "{0}" (ID {1})'.format(ROMFile.getBase(), rom_id))
 
@@ -1699,7 +1700,7 @@ class Main:
                                 if not asset_DB_file:
                                     # log_debug('Search  {0} in PClone set'.format(AInfo.name))
                                     for set_rom_id in pclone_set_id_list:
-                                        # ROMFile_t = FileName(roms[set_rom_id]['filename'])
+                                        # ROMFile_t = FileNameFactory.create(roms[set_rom_id]['filename'])
                                         # log_debug('PClone group ROM "{0}" (ID) {1})'.format(ROMFile_t.getBase(), set_rom_id))
                                         asset_DB_file_t = roms[set_rom_id][AInfo.key]
                                         if asset_DB_file_t:
@@ -1822,7 +1823,7 @@ class Main:
                 # --- Delete ROMs metadata NFO files ---
                 elif type2 == 7:
                     # --- Get list of NFO files ---
-                    ROMPath_FileName = FileName(self.launchers[launcherID]['rompath'])
+                    ROMPath_FileName = FileNameFactory.create(self.launchers[launcherID]['rompath'])
                     log_verb('_command_edit_launcher() NFO dirname "{0}"'.format(ROMPath_FileName.getPath()))
 
                     nfo_scanned_files = ROMPath_FileName.recursiveScanFilesInPath('*.nfo')
@@ -1839,7 +1840,7 @@ class Main:
                     # --- Delete NFO files ---
                     for file in nfo_scanned_files:
                         log_verb('_command_edit_launcher() RM "{0}"'.format(file))
-                        FileName(file).unlink()
+                        FileNameFactory.create(file).unlink()
 
                     # >> No need to save launchers XML / Update container
                     kodi_notify('Deleted {0} NFO files'.format(len(nfo_scanned_files)))
@@ -1940,7 +1941,7 @@ class Main:
                         # >> Check if user configured a No-Intro DAT. If not configured  or file does
                         # >> not exists refuse to switch to PClone view and force normal mode.
                         nointro_xml_file = launcher['nointro_xml_file']
-                        nointro_xml_file_FName = FileName(nointro_xml_file)
+                        nointro_xml_file_FName = FileNameFactory.create(nointro_xml_file)
                         if not nointro_xml_file:
                             log_info('_command_edit_launcher() No-Intro DAT not configured.')
                             log_info('_command_edit_launcher() Forcing Flat view mode.')
@@ -1994,7 +1995,7 @@ class Main:
                         # Fixed in Krypton Beta 6 http://forum.kodi.tv/showthread.php?tid=298161
                         dialog = xbmcgui.Dialog()
                         dat_file = dialog.browse(1, 'Select No-Intro XML DAT (XML|DAT)', 'files', '.dat|.xml').decode('utf-8')
-                        if not FileName(dat_file).exists(): return
+                        if not FileNameFactory.create(dat_file).exists(): return
                         self.launchers[launcherID]['nointro_xml_file'] = dat_file
                         kodi_dialog_OK('DAT file successfully added. Launcher ROMs will be audited now.')
 
@@ -2003,7 +2004,7 @@ class Main:
                         # _roms_update_NoIntro_status() does not save ROMs JSON/XML.
                         launcher = self.launchers[launcherID]
                         roms = fs_load_ROMs_JSON(ROMS_DIR, launcher)
-                        nointro_xml_FN = FileName(launcher['nointro_xml_file'])
+                        nointro_xml_FN = FileNameFactory.create(launcher['nointro_xml_file'])
                         if self._roms_update_NoIntro_status(launcher, roms, nointro_xml_FN):
                             fs_write_ROMs_JSON(ROMS_DIR, launcher, roms)
                             kodi_notify('Added No-Intro/Redump XML DAT. '
@@ -2065,7 +2066,7 @@ class Main:
                     # _roms_update_NoIntro_status() does not save ROMs JSON/XML.
                     launcher = self.launchers[launcherID]
                     roms = fs_load_ROMs_JSON(ROMS_DIR, launcher)
-                    nointro_xml_FN = FileName(launcher['nointro_xml_file'])
+                    nointro_xml_FN = FileNameFactory.create(launcher['nointro_xml_file'])
                     if self._roms_update_NoIntro_status(launcher, roms, nointro_xml_FN):
                         pDialog = xbmcgui.DialogProgress()
                         pDialog.create('Advanced Emulator Launcher', 'Saving ROM JSON database ...')
@@ -2259,7 +2260,7 @@ class Main:
             dir_path = xbmcgui.Dialog().browse(0, 'Select XML export directory', 'files', 
                                                '', False, False).decode('utf-8')
             if not dir_path: return
-            export_FN = FileName(dir_path).pjoin(launcher_fn_str)
+            export_FN = FileNameFactory.create(dir_path).pjoin(launcher_fn_str)
             if export_FN.exists():
                 ret = kodi_dialog_yesno('Overwrite file {0}?'.format(export_FN.getPath()))
                 if not ret:
@@ -2484,7 +2485,7 @@ class Main:
                 dialog = xbmcgui.Dialog()
                 text_file = dialog.browse(1, 'Select description file (TXT|DAT)', 
                                           'files', '.txt|.dat', False, False).decode('utf-8')
-                text_file_path = FileName(text_file)
+                text_file_path = FileNameFactory.create(text_file)
                 if text_file_path.exists():
                     file_data = self._gui_import_TXT_file(text_file_path)
                     roms[romID]['m_plot'] = file_data
@@ -2673,7 +2674,7 @@ class Main:
             # --- If there is a No-Intro XML configured audit ROMs ---
             if is_Normal_Launcher and launcher['nointro_xml_file']:
                 log_info('No-Intro/Redump DAT configured. Starting ROM audit ...')
-                nointro_xml_FN = FileName(launcher['nointro_xml_file'])
+                nointro_xml_FN = FileNameFactory.create(launcher['nointro_xml_file'])
                 if not self._roms_update_NoIntro_status(launcher, roms, nointro_xml_FN):
                     self.launchers[launcherID]['nointro_xml_file'] = ''
                     kodi_notify_warn('Error auditing ROMs. XML DAT file unset.')
@@ -4657,13 +4658,13 @@ class Main:
                 log_info('_command_manage_favourites() Fav ROM status "{0}"'.format(roms_fav[rom_fav_ID]['fav_status']))
 
                 # >> Traverse all launchers and find rom by filename or base name
-                ROM_FN_FAV = FileName(roms_fav[rom_fav_ID]['filename'])
+                ROM_FN_FAV = FileNameFactory.create(roms_fav[rom_fav_ID]['filename'])
                 filename_found = False
                 for launcher_id in self.launchers:
                     # >> Load launcher ROMs
                     roms = fs_load_ROMs_JSON(ROMS_DIR, self.launchers[launcher_id])
                     for rom_id in roms:
-                        ROM_FN = FileName(roms[rom_id]['filename'])
+                        ROM_FN = FileNameFactory.create(roms[rom_id]['filename'])
                         fav_name = roms_fav[rom_fav_ID]['m_name']
                         if type == 1 and roms_fav[rom_fav_ID]['filename'] == roms[rom_id]['filename']:
                             log_info('_command_manage_favourites() Favourite {0} matched by filename!'.format(fav_name))
@@ -4777,9 +4778,9 @@ class Main:
 
                 # >> Is there a ROM with same basename (including extension) as the Favourite ROM?
                 filename_found = False
-                ROM_FAV_FN = FileName(rom_fav['filename'])
+                ROM_FAV_FN = FileNameFactory.create(rom_fav['filename'])
                 for rom_id in launcher_roms:
-                    ROM_FN = FileName(launcher_roms[rom_id]['filename'])
+                    ROM_FN = FileNameFactory.create(launcher_roms[rom_id]['filename'])
                     if ROM_FAV_FN.getBase() == ROM_FN.getBase():
                         filename_found = True
                         new_fav_rom_ID = rom_id
@@ -4921,7 +4922,7 @@ class Main:
         for rom_fav_ID in roms_fav:
             pDialog.update(i * 100 / num_progress_items)
             i += 1
-            romFile = FileName(roms_fav[rom_fav_ID]['filename'])
+            romFile = FileNameFactory.create(roms_fav[rom_fav_ID]['filename'])
             if not romFile.exists():
                 log_verb('Fav ROM "{0}" broken because filename does not exist'.format(roms_fav[rom_fav_ID]['m_name']))
                 roms_fav[rom_fav_ID]['fav_status'] = 'Broken'
@@ -4965,7 +4966,7 @@ class Main:
                              'banner' : banner_path, 'poster' : poster_path, 'clearlogo' : clearlogo_path})
 
             # --- Extrafanart ---
-            collections_asset_dir = FileName(self.settings['collections_asset_dir'])
+            collections_asset_dir = FileNameFactory.create(self.settings['collections_asset_dir'])
             extrafanart_dir = collections_asset_dir + collection['m_name']
             log_debug('_command_render_collections() EF dir {0}'.format(extrafanart_dir.getPath()))
             extrafanart_dic = {}
@@ -5142,7 +5143,7 @@ class Main:
                 NFO_file = xbmcgui.Dialog().browse(1, 'Select NFO description file', 'files', '.nfo', False, False).decode('utf-8')
                 log_debug('_command_edit_category() Dialog().browse returned "{0}"'.format(NFO_file))
                 if not NFO_file: return
-                NFO_FileName = FileName(NFO_file)
+                NFO_FileName = FileNameFactory.create(NFO_file)
                 if not NFO_FileName.exists(): return
                 # >> Returns True if changes were made
                 if not fs_import_collection_NFO(NFO_FileName, collections, launcherID): return
@@ -5338,7 +5339,7 @@ class Main:
         if not collection_file_str: return
 
         # --- Load ROM Collection file ---
-        collection_FN = FileName(collection_file_str)
+        collection_FN = FileNameFactory.create(collection_file_str)
         control_dic, collection_dic, collection_rom_list = fs_import_ROM_collection(collection_FN)
         if not collection_dic:
             kodi_dialog_OK('Error reading Collection JSON file. JSON file corrupted or wrong.')
@@ -5351,7 +5352,7 @@ class Main:
             return
 
         # --- Check if asset JSON exist. If so, ask the user about importing it. ---
-        collection_asset_FN = FileName(collection_FN.getPath_noext() + '_assets.json')
+        collection_asset_FN = FileNameFactory.create(collection_FN.getPath_noext() + '_assets.json')
         log_debug('_command_import_collection() collection_asset_FN "{0}"'.format(collection_asset_FN.getPath()))
         import_collection_assets = False
         if collection_asset_FN.exists():
@@ -5379,7 +5380,7 @@ class Main:
 
         # --- Also import assets if loaded ---
         if import_collection_assets:
-            collections_asset_dir_FN = FileName(self.settings['collections_asset_dir'])
+            collections_asset_dir_FN = FileNameFactory.create(self.settings['collections_asset_dir'])
 
             # --- Import Collection assets ---
             log_info('_command_import_collection() Importing ROM Collection assets ...')
@@ -5426,7 +5427,7 @@ class Main:
                 for asset_kind in ROM_ASSET_LIST:
                     # >> Get assets filename with no extension
                     AInfo = assets_get_info_scheme(asset_kind)
-                    ROM_FN = FileName(rom_item['filename'])                    
+                    ROM_FN = FileNameFactory.create(rom_item['filename'])                    
                     ROM_asset_noext_FN = assets_get_path_noext_SUFIX(AInfo, collections_asset_dir_FN, 
                                                                      ROM_FN.getBase_noext(), rom_item['id'])
                     ROM_asset_FN = ROM_asset_noext_FN.append(ROM_asset_noext_FN.getExt())
@@ -5487,7 +5488,7 @@ class Main:
         dialog = xbmcgui.Dialog()
         output_dir = dialog.browse(3, 'Select Collection output directory', 'files').decode('utf-8')
         if not output_dir: return
-        output_dir_FileName = FileName(output_dir)
+        output_dir_FileName = FileNameFactory.create(output_dir)
 
         # --- Load collection ROMs ---
         (collections, update_timestamp) = fs_load_Collection_index_XML(COLLECTIONS_FILE_PATH)
@@ -5514,11 +5515,11 @@ class Main:
 
             # --- Copy Collection assets to Collection asset directory ---
             log_info('_command_export_collection() Copying ROM Collection assets ...')
-            collections_asset_dir_FN = FileName(self.settings['collections_asset_dir'])
+            collections_asset_dir_FN = FileNameFactory.create(self.settings['collections_asset_dir'])
             collection_assets_were_copied = False
             for asset_kind in CATEGORY_ASSET_LIST:
                 AInfo = assets_get_info_scheme(asset_kind)
-                asset_FileName = FileName(collection[AInfo.key])
+                asset_FileName = FileNameFactory.create(collection[AInfo.key])
                 new_asset_noext_FileName = assets_get_path_noext_SUFIX(AInfo, collections_asset_dir_FN,
                                                                        collection['m_name'], collection['id'])
                 new_asset_FileName = new_asset_noext_FileName.append(asset_FileName.getExt())
@@ -5565,8 +5566,8 @@ class Main:
                 log_debug('_command_export_collection() ROM "{0}"'.format(rom_item['m_name']))
                 for asset_kind in ROM_ASSET_LIST:
                     AInfo = assets_get_info_scheme(asset_kind)
-                    asset_FileName = FileName(rom_item[AInfo.key])
-                    ROM_FileName = FileName(rom_item['filename'])
+                    asset_FileName = FileNameFactory.create(rom_item[AInfo.key])
+                    ROM_FileName = FileNameFactory.create(rom_item['filename'])
                     new_asset_noext_FileName = assets_get_path_noext_SUFIX(AInfo, collections_asset_dir_FN, 
                                                                            ROM_FileName.getBase_noext(), rom_item['id'])
                     new_asset_FileName = new_asset_noext_FileName.append(asset_FileName.getExt())
@@ -6374,7 +6375,7 @@ class Main:
             if not s_map:
                 kodi_dialog_OK('Map image file not set for ROM "{0}"'.format(rom['m_name']))
                 return
-            map_FN = FileName(s_map)
+            map_FN = FileNameFactory.create(s_map)
             if not map_FN.exists():
                 kodi_dialog_OK('Map image file not found.')
                 return
@@ -7026,11 +7027,11 @@ class Main:
         audit_none = audit_have = audit_miss = audit_unknown = 0
         audit_num_parents = audit_num_clones = 0
         check_list = []
-        path_title_P = FileName(launcher['path_title']).getPath()
-        path_snap_P = FileName(launcher['path_snap']).getPath()
-        path_boxfront_P = FileName(launcher['path_boxfront']).getPath()
-        path_boxback_P = FileName(launcher['path_boxback']).getPath()
-        path_cartridge_P = FileName(launcher['path_cartridge']).getPath()
+        path_title_P = FileNameFactory.create(launcher['path_title']).getPath()
+        path_snap_P = FileNameFactory.create(launcher['path_snap']).getPath()
+        path_boxfront_P = FileNameFactory.create(launcher['path_boxfront']).getPath()
+        path_boxback_P = FileNameFactory.create(launcher['path_boxback']).getPath()
+        path_cartridge_P = FileNameFactory.create(launcher['path_cartridge']).getPath()
         for rom_id in sorted(roms, key = lambda x : roms[x]['m_name']):
             rom = roms[rom_id]
             rom_info = {}
@@ -7062,30 +7063,30 @@ class Main:
             # path_* and art getDir() equal and Base_noext() different ==> Maybe S or maybe C => O
             # To differentiate between S and C a test in the PClone group must be done.
             #
-            romfile_FN = FileName(rom['filename'])
+            romfile_FN = FileNameFactory.create(rom['filename'])
             romfile_getBase_noext = romfile_FN.getBase_noext()
             if rom['s_title']:
-                rom_info['s_title'] = self._aux_get_info(FileName(rom['s_title']), path_title_P, romfile_getBase_noext)
+                rom_info['s_title'] = self._aux_get_info(FileNameFactory.create(rom['s_title']), path_title_P, romfile_getBase_noext)
             else:
                 rom_info['s_title'] = '-'
                 missing_s_title += 1
             if rom['s_snap']:
-                rom_info['s_snap'] = self._aux_get_info(FileName(rom['s_snap']), path_snap_P, romfile_getBase_noext)
+                rom_info['s_snap'] = self._aux_get_info(FileNameFactory.create(rom['s_snap']), path_snap_P, romfile_getBase_noext)
             else:
                 rom_info['s_snap'] = '-'
                 missing_s_snap += 1
             if rom['s_boxfront']:
-                rom_info['s_boxfront'] = self._aux_get_info(FileName(rom['s_boxfront']), path_boxfront_P, romfile_getBase_noext)
+                rom_info['s_boxfront'] = self._aux_get_info(FileNameFactory.create(rom['s_boxfront']), path_boxfront_P, romfile_getBase_noext)
             else:
                 rom_info['s_boxfront'] = '-'
                 missing_s_boxfront += 1
             if rom['s_boxback']:
-                rom_info['s_boxback'] = self._aux_get_info(FileName(rom['s_boxback']), path_boxback_P, romfile_getBase_noext)
+                rom_info['s_boxback'] = self._aux_get_info(FileNameFactory.create(rom['s_boxback']), path_boxback_P, romfile_getBase_noext)
             else:
                 rom_info['s_boxback'] = '-'
                 missing_s_boxback += 1
             if rom['s_cartridge']:
-                rom_info['s_cartridge'] = self._aux_get_info(FileName(rom['s_cartridge']), path_cartridge_P, romfile_getBase_noext)
+                rom_info['s_cartridge'] = self._aux_get_info(FileNameFactory.create(rom['s_cartridge']), path_cartridge_P, romfile_getBase_noext)
             else:                  
                 rom_info['s_cartridge'] = '-'
                 missing_s_cartridge += 1
@@ -7333,7 +7334,7 @@ class Main:
 
         # --- Format title ---
         scan_clean_tags = self.settings['scan_clean_tags']
-        ROMFile = FileName(romfile)
+        ROMFile = FileNameFactory.create(romfile)
         rom_name = text_format_ROM_title(ROMFile.getBase_noext(), scan_clean_tags)
 
         # ~~~ Check asset dirs and disable scanning for unset dirs ~~~
@@ -7383,7 +7384,7 @@ class Main:
         # --- If there is a No-Intro XML configured audit ROMs ---
         if launcher['nointro_xml_file']:
             log_info('No-Intro/Redump DAT configured. Starting ROM audit ...')
-            nointro_xml_FN = FileName(launcher['nointro_xml_file'])
+            nointro_xml_FN = FileNameFactory.create(launcher['nointro_xml_file'])
             if not self._roms_update_NoIntro_status(launcher, roms, nointro_xml_FN):
                 self.launchers[launcherID]['nointro_xml_file'] = ''
                 kodi_dialog_OK('Error auditing ROMs. XML DAT file unset.')
@@ -7442,7 +7443,7 @@ class Main:
         
         log_info('No-Intro/Redump DAT configured. Starting ROM audit ...')
         roms_base_noext = launcher['roms_base_noext']
-        nointro_xml_FN = FileName(launcher['nointro_xml_file'])
+        nointro_xml_FN = FileNameFactory.create(launcher['nointro_xml_file'])
                 
         nointro_scanner = RomDatFileScanner(self.settings, self.romsetFactory)
 
@@ -7480,7 +7481,7 @@ class Main:
         else:
             launcher = self.launchers[launcherID]
             platform = launcher['platform']
-        ROM      = FileName(roms[romID]['filename'])
+        ROM      = FileNameFactory.create(roms[romID]['filename'])
         rom_name = roms[romID]['m_name']
         scan_clean_tags            = self.settings['scan_clean_tags']
         scan_ignore_scrapped_title = self.settings['scan_ignore_scrap_title']
@@ -7627,7 +7628,7 @@ class Main:
             # --- Grab asset information for editing ---
             object_name = 'Category'
             AInfo = assets_get_info_scheme(asset_kind)
-            asset_directory = FileName(self.settings['categories_asset_dir'])
+            asset_directory = FileNameFactory.create(self.settings['categories_asset_dir'])
             asset_path_noext = assets_get_path_noext_SUFIX(AInfo, asset_directory, object_dic['m_name'], object_dic['id'])
             log_info('_gui_edit_asset() Editing Category "{0}"'.format(AInfo.name))
             log_info('_gui_edit_asset() ID {0}'.format(object_dic['id']))
@@ -7643,7 +7644,7 @@ class Main:
             # --- Grab asset information for editing ---
             object_name = 'Collection'
             AInfo = assets_get_info_scheme(asset_kind)
-            asset_directory = FileName(self.settings['collections_asset_dir'])
+            asset_directory = FileNameFactory.create(self.settings['collections_asset_dir'])
             asset_path_noext = assets_get_path_noext_SUFIX(AInfo, asset_directory, object_dic['m_name'], object_dic['id'])
             log_info('_gui_edit_asset() Editing Collection "{0}"'.format(AInfo.name))
             log_info('_gui_edit_asset() ID {0}'.format(object_dic['id']))
@@ -7658,7 +7659,7 @@ class Main:
             # --- Grab asset information for editing ---
             object_name = 'Launcher'
             AInfo = assets_get_info_scheme(asset_kind)
-            asset_directory = FileName(self.settings['launchers_asset_dir'])
+            asset_directory = FileNameFactory.create(self.settings['launchers_asset_dir'])
             asset_path_noext = assets_get_path_noext_SUFIX(AInfo, asset_directory, object_dic['m_name'], object_dic['id'])
             log_info('_gui_edit_asset() Editing Launcher "{0}"'.format(AInfo.name))
             log_info('_gui_edit_asset() ID {0}'.format(object_dic['id']))
@@ -7672,25 +7673,25 @@ class Main:
         elif object_kind == KIND_ROM:
             # --- Grab asset information for editing ---
             object_name = 'ROM'
-            ROMfile = FileName(object_dic['filename'])
+            ROMfile = FileNameFactory.create(object_dic['filename'])
             AInfo   = assets_get_info_scheme(asset_kind)
             if categoryID == VCATEGORY_FAVOURITES_ID:
                 log_info('_gui_edit_asset() ROM is in Favourites')
-                asset_directory  = FileName(self.settings['favourites_asset_dir'])
+                asset_directory  = FileNameFactory.create(self.settings['favourites_asset_dir'])
                 platform         = object_dic['platform']
                 asset_path_noext = assets_get_path_noext_SUFIX(AInfo, asset_directory, ROMfile.getBase_noext(), object_dic['id'])
             elif categoryID == VCATEGORY_COLLECTIONS_ID:
                 log_info('_gui_edit_asset() ROM is in Collection')
-                asset_directory  = FileName(self.settings['collections_asset_dir'])
+                asset_directory  = FileNameFactory.create(self.settings['collections_asset_dir'])
                 platform         = object_dic['platform']
                 asset_path_noext = assets_get_path_noext_SUFIX(AInfo, asset_directory, ROMfile.getBase_noext(), object_dic['id'])
             else:
                 log_info('_gui_edit_asset() ROM is in Launcher id {0}'.format(launcherID))
                 launcher         = self.launchers[launcherID]
-                asset_directory  = FileName(launcher[AInfo.path_key])
+                asset_directory  = FileNameFactory.create(launcher[AInfo.path_key])
                 platform         = launcher['platform']
                 asset_path_noext = assets_get_path_noext_DIR(AInfo, asset_directory, ROMfile)
-            current_asset_path = FileName(object_dic[AInfo.key])
+            current_asset_path = FileNameFactory.create(object_dic[AInfo.key])
             log_info('_gui_edit_asset() Editing ROM {0}'.format(AInfo.name))
             log_info('_gui_edit_asset() ROM ID {0}'.format(object_dic['id']))
             log_debug('_gui_edit_asset() asset_directory    "{0}"'.format(asset_directory.getOriginalPath()))
@@ -7739,7 +7740,7 @@ class Main:
 
         # --- Link to a local image ---
         if type2 == 0:
-            image_dir = FileName(object_dic[AInfo.key]).getDir() if object_dic[AInfo.key] else ''
+            image_dir = FileNameFactory.create(object_dic[AInfo.key]).getDir() if object_dic[AInfo.key] else ''
 
             log_debug('_gui_edit_asset() Initial path "{0}"'.format(image_dir))
             # >> ShowAndGetFile dialog
@@ -7752,7 +7753,7 @@ class Main:
                 image_file = dialog.browse(2, 'Select {0} {1}'.format(AInfo.name, AInfo.kind_str), 'files',
                                            AInfo.exts_dialog, True, False, image_dir)
             if not image_file: return False
-            image_file_path = FileName(image_file)
+            image_file_path = FileNameFactory.create(image_file)
             if not image_file or not image_file_path.exists(): return False
 
             # --- Update object by assigment. XML/JSON will be save by parent ---
@@ -7769,11 +7770,11 @@ class Main:
         elif type2 == 1:
             # >> If assets exists start file dialog from current asset directory
             image_dir = ''
-            if object_dic[AInfo.key]: image_dir = FileName(object_dic[AInfo.key]).getDir()
+            if object_dic[AInfo.key]: image_dir = FileNameFactory.create(object_dic[AInfo.key]).getDir()
             log_debug('_gui_edit_asset() Initial path "{0}"'.format(image_dir))
             image_file = xbmcgui.Dialog().browse(2, 'Select {0} image'.format(AInfo.name), 'files',
                                                  AInfo.exts_dialog, True, False, image_dir)
-            image_FileName = FileName(image_file)
+            image_FileName = FileNameFactory.create(image_file)
             if not image_FileName.exists(): return False
 
             # >> Determine image extension and dest filename. Check for errors.
@@ -8005,7 +8006,7 @@ class Main:
         for xml_file in file_list:
             xml_file_unicode = xml_file.decode('utf-8')
             log_debug('_command_import_launchers() Importing "{0}"'.format(xml_file_unicode))
-            import_FN = FileName(xml_file_unicode)
+            import_FN = FileNameFactory.create(xml_file_unicode)
             if not import_FN.exists(): continue
             # >> This function edits self.categories, self.launchers dictionaries
             autoconfig_import_launchers(CATEGORIES_FILE_PATH, ROMS_DIR, self.categories, self.launchers, import_FN)
@@ -8027,7 +8028,7 @@ class Main:
         if not dir_path: return
 
         # --- If XML exists then warn user about overwriting it ---
-        export_FN = FileName(dir_path).pjoin('AEL_configuration.xml')
+        export_FN = FileNameFactory.create(dir_path).pjoin('AEL_configuration.xml')
         if export_FN.exists():
             ret = kodi_dialog_yesno('AEL_configuration.xml found in the selected directory. Overwrite?')
             if not ret:
@@ -8268,20 +8269,20 @@ class Main:
                 l_str.append('Category not found (unlinked launcher)\n')
 
             # >> Check that application exists
-            app_FN = FileName(launcher['application'])
+            app_FN = FileNameFactory.create(launcher['application'])
             if not app_FN.exists():
                 l_str.append('Application "{0}" not found\n'.format(app_FN.getPath()))
 
             # >> Check that rompath exists if rompath is not empty
             # >> Empty rompath means standalone launcher
             rompath = launcher['rompath']
-            rompath_FN = FileName(rompath)
+            rompath_FN = FileNameFactory.create(rompath)
             if rompath and not rompath_FN.exists():
                 l_str.append('ROM path "{0}" not found\n'.format(rompath_FN.getPath()))
 
             # >> Check that DAT file exists if not empty
             nointro_xml_file = launcher['nointro_xml_file']
-            nointro_xml_file_FN = FileName(nointro_xml_file)
+            nointro_xml_file_FN = FileNameFactory.create(nointro_xml_file)
             if nointro_xml_file and not nointro_xml_file_FN.exists():
                 l_str.append('DAT file "{0}" not found\n'.format(nointro_xml_file_FN.getPath()))
 
@@ -8296,7 +8297,7 @@ class Main:
 
             # >> Test that ROM_asset_path exists if not empty
             ROM_asset_path = launcher['ROM_asset_path']
-            ROM_asset_path_FN = FileName(ROM_asset_path)
+            ROM_asset_path_FN = FileNameFactory.create(ROM_asset_path)
             if ROM_asset_path and not ROM_asset_path_FN.exists():
                 l_str.append('ROM_asset_path "{0}" not found\n'.format(ROM_asset_path_FN.getPath()))
 
@@ -8340,7 +8341,7 @@ class Main:
 
     def _aux_check_for_file(self, str_list, dic_key_name, launcher):
         path = launcher[dic_key_name]
-        path_FN = FileName(path)
+        path_FN = FileNameFactory.create(path)
         if path and not path_FN.exists():
             problems_found = True
             str_list.append('{0} "{1}" not found\n'.format(dic_key_name, path_FN.getPath()))
@@ -8351,7 +8352,7 @@ class Main:
         log_info('_command_check_retro_BIOS() check_only_mandatory = {0}'.format(check_only_mandatory))
 
         # >> If Retroarch System dir not configured or found abort.
-        sys_dir_FN = FileName(self.settings['io_retroarch_sys_dir'])
+        sys_dir_FN = FileNameFactory.create(self.settings['io_retroarch_sys_dir'])
         if not sys_dir_FN.exists():
             kodi_dialog_OK('Retroarch System directory not found. Please configure it.')
             return
@@ -8502,7 +8503,7 @@ class Main:
         if not ret: return
 
         kodi_notify('Importing AL launchers.xml ...')
-        AL_DATA_DIR = FileName('special://profile/addon_data/plugin.program.advanced.launcher')
+        AL_DATA_DIR = FileNameFactory.create('special://profile/addon_data/plugin.program.advanced.launcher')
         LAUNCHERS_FILE_PATH = AL_DATA_DIR.pjoin('launchers.xml')
         FIXED_LAUNCHERS_FILE_PATH = PLUGIN_DATA_DIR.pjoin('fixed_launchers.xml')
 
@@ -8656,13 +8657,13 @@ class Main:
         path = ""
         try:
             skinshortcutsAddon = xbmcaddon.Addon('script.skinshortcuts')
-            path = FileName(skinshortcutsAddon.getAddonInfo('path'))
+            path = FileNameFactory.create(skinshortcutsAddon.getAddonInfo('path'))
 
             libPath = path.pjoin('resources', 'lib')
             sys.path.append(libPath.getPath())
 
             unidecodeModule = xbmcaddon.Addon('script.module.unidecode')
-            libPath = FileName(unidecodeModule.getAddonInfo('path'))
+            libPath = FileNameFactory.create(unidecodeModule.getAddonInfo('path'))
             libPath = libPath.pjoin('lib')
             sys.path.append(libPath.getPath())
 

--- a/resources/reporting.py
+++ b/resources/reporting.py
@@ -57,7 +57,7 @@ class FileReporter(Reporter):
         self.report_file.open('w')
 
         # --- Get information from launcher ---
-        launcher_path = FileName(self.launcher['rompath'])
+        launcher_path = FileNameFactory.create(self.launcher['rompath'])
         
         self.write('******************** Report: {} ...  ********************'.format(report_title))
         self.write('  Launcher name "{0}"'.format(self.launcher['m_name']))

--- a/resources/rom_audit.py
+++ b/resources/rom_audit.py
@@ -498,7 +498,7 @@ def audit_generate_DAT_PClone_index(roms, roms_nointro, unknown_ROMs_are_parents
     names_to_ids_dic = {}
     for rom_id in roms:
         rom = roms[rom_id]
-        ROMFileName = FileName(rom['filename'])
+        ROMFileName = FileNameFactory.create(rom['filename'])
         rom_name = ROMFileName.getBase_noext()
         # log_debug('{0} --> {1}'.format(rom_name, rom_id))
         # log_debug('{0}'.format(rom))
@@ -507,7 +507,7 @@ def audit_generate_DAT_PClone_index(roms, roms_nointro, unknown_ROMs_are_parents
     # --- Build PClone dictionary using ROM base_noext names ---
     for rom_id in roms:
         rom = roms[rom_id]
-        ROMFileName = FileName(rom['filename'])
+        ROMFileName = FileNameFactory.create(rom['filename'])
         rom_nointro_name = ROMFileName.getBase_noext()
         # log_debug('rom_id {0}'.format(rom_id))
         # log_debug('  nointro_status   "{0}"'.format(rom['nointro_status']))

--- a/resources/rom_datfile_scanner.py
+++ b/resources/rom_datfile_scanner.py
@@ -90,7 +90,7 @@ class RomDatFileScanner(ProgressDialogStrategy):
         roms_set = set()
         for rom_id in roms:
             # >> Use the ROM basename.
-            ROMFileName = FileName(roms[rom_id]['filename'])
+            ROMFileName = FileNameFactory.create(roms[rom_id]['filename'])
             roms_set.add(ROMFileName.getBase_noext())
         self._updateProgress(100)
         if __debug_progress_dialogs: time.sleep(0.5)
@@ -100,7 +100,7 @@ class RomDatFileScanner(ProgressDialogStrategy):
         num_items = len(roms)
         item_counter = 0
         for rom_id in roms:
-            ROMFileName = FileName(roms[rom_id]['filename'])
+            ROMFileName = FileNameFactory.create(roms[rom_id]['filename'])
             if ROMFileName.getBase_noext() in roms_nointro_set:
                 roms[rom_id]['nointro_status'] = NOINTRO_STATUS_HAVE
                 audit_have += 1
@@ -119,7 +119,7 @@ class RomDatFileScanner(ProgressDialogStrategy):
         num_items = len(roms)
         item_counter = 0
         for rom_id in roms:
-            ROMFileName = FileName(roms[rom_id]['filename'])
+            ROMFileName = FileNameFactory.create(roms[rom_id]['filename'])
             if not ROMFileName.exists():
                 roms[rom_id]['nointro_status'] = NOINTRO_STATUS_MISS
                 audit_miss += 1
@@ -135,7 +135,7 @@ class RomDatFileScanner(ProgressDialogStrategy):
         self._updateProgress(0, 'Audit Step 3/4: Adding Missing ROMs ...')
         num_items = len(roms_nointro_set)
         item_counter = 0
-        ROMPath = FileName(launcher['rompath'])
+        ROMPath = FileNameFactory.create(launcher['rompath'])
         for nointro_rom in sorted(roms_nointro_set):
             # log_debug('_roms_update_NoIntro_status() Checking "{0}"'.format(nointro_rom))
             if nointro_rom not in roms_set:
@@ -318,7 +318,7 @@ class RomDatFileScanner(ProgressDialogStrategy):
                 if not roms[rom_id]['filename']:
                     log_debug('_roms_delete_missing_ROMs() Skip "{0}"'.format(roms[rom_id]['m_name']))
                     continue
-                ROMFileName = FileName(roms[rom_id]['filename'])
+                ROMFileName = FileNameFactory.create(roms[rom_id]['filename'])
                 log_debug('_roms_delete_missing_ROMs() Test "{0}"'.format(ROMFileName.getBase()))
                 # --- Remove missing ROMs ---
                 if not ROMFileName.exists():

--- a/resources/romscanners.py
+++ b/resources/romscanners.py
@@ -18,6 +18,7 @@ from reporting import *
 from disk_IO import *
 from utils import *
 from utils_kodi import *
+from filename import *
 
 class RomScannersFactory():
 
@@ -200,7 +201,7 @@ class RomFolderScanner(RomScannerStrategy):
         kodi_busydialog_ON()
         
         files = []
-        launcher_path = FileName(self.launcher['rompath'])
+        launcher_path = FileNameFactory.create(self.launcher['rompath'])
         launcher_report.write('Scanning files in {0}'.format(launcher_path.getOriginalPath()))
 
         if self.settings['scan_recursive']:
@@ -235,7 +236,7 @@ class RomFolderScanner(RomScannerStrategy):
             log_debug('Searching {0}'.format(roms[key]['filename']))
             self._updateProgress(i * 100 / num_roms)
             i += 1
-            fileName = FileName(roms[key]['filename'])
+            fileName = FileNameFactory.create(roms[key]['filename'])
             if not fileName.exists():
                 log_debug('Not found')
                 log_debug('Deleting from DB {0}'.format(roms[key]['filename']))
@@ -264,7 +265,7 @@ class RomFolderScanner(RomScannerStrategy):
             self._updateProgress(num_items_checked * 100 / num_items)
             
             # --- Get all file name combinations ---
-            ROM = FileName(item)
+            ROM = FileNameFactory.create(item)
             launcher_report.write('>>> {0}'.format(ROM.getOriginalPath()).encode('utf-8'))
 
             # ~~~ Update progress dialog ~~~
@@ -303,7 +304,7 @@ class RomFolderScanner(RomScannerStrategy):
                 # >> Check if the set is already in launcher ROMs.
                 MultiDisc_rom_id = None
                 for new_rom in new_roms:
-                    temp_FN = FileName(new_rom['filename'])
+                    temp_FN = FileNameFactory.create(new_rom['filename'])
                     if temp_FN.getBase() == MDSet.setName:
                         MultiDiscInROMs  = True
                         MultiDisc_rom    = new_rom
@@ -316,7 +317,7 @@ class RomFolderScanner(RomScannerStrategy):
                 if not MultiDiscInROMs:
                     log_info('First ROM in the set. Adding to ROMs ...')
                     # >> Manipulate ROM so filename is the name of the set
-                    ROM_dir = FileName(ROM.getDir())
+                    ROM_dir = FileNameFactory.create(ROM.getDir())
                     ROM_temp = ROM_dir.pjoin(MDSet.setName)
                     log_info('ROM_temp OP "{0}"'.format(ROM_temp.getOriginalPath()))
                     log_info('ROM_temp  P "{0}"'.format(ROM_temp.getPath()))
@@ -488,7 +489,7 @@ class SteamScanner(RomScannerStrategy):
         
                 log_debug('Not found. Item {0} is new'.format(steamGame['name']))
 
-                launcher_path = FileName(self.launcher['rompath'])
+                launcher_path = FileNameFactory.create(self.launcher['rompath'])
                 romPath = launcher_path.pjoin('{0}.rom'.format(steamGame['appid']))
 
                 # ~~~~~ Process new ROM and add to the list ~~~~~

--- a/resources/scrap_metadata.py
+++ b/resources/scrap_metadata.py
@@ -79,7 +79,7 @@ class metadata_Offline(Scraper_Metadata):
 
         # Load XML database and keep it in memory for subsequent calls
         #xml_path = os.path.join(self.addon_dir, xml_file)
-        xml_path = FileName(self.addon_dir)
+        xml_path = FileNameFactory.create(self.addon_dir)
         xml_path = xml_path.pjoin(xml_file)
         log_debug('metadata_Offline::initialise_scraper Loading XML {0}'.format(xml_path))
         self.games = rom_audit.audit_load_OfflineScraper_XML(xml_path)

--- a/resources/scrapers.py
+++ b/resources/scrapers.py
@@ -437,7 +437,7 @@ class OnlineAssetScraper(Scraper):
         self.asset_kind = asset_kind
         self.asset_info = asset_info
 
-        self.asset_directory = FileName(launcher[asset_info.path_key])
+        self.asset_directory = FileNameFactory.create(launcher[asset_info.path_key])
         scraping_mode = settings['asset_scraper_mode']
         
         # --- Initialise cache used in OnlineAssetScraper() as a static variable ---

--- a/resources/utils.py
+++ b/resources/utils.py
@@ -32,6 +32,9 @@ import string
 import fnmatch
 import HTMLParser
 
+from filename import *
+from utils_kodi import *
+
 # --- AEL modules ---
 # >> utils.py must not depend on any other AEL module to avoid circular dependencies.
 
@@ -380,7 +383,7 @@ def text_get_multidisc_info(ROM_FN):
 #
 def text_get_URL_extension(url):
     
-    urlPath = FileName(url)
+    urlPath = FileNameFactory.create(url)
     return urlPath.getExt()
 
 #
@@ -403,7 +406,7 @@ def misc_add_file_cache(dir_str):
     if not dir_str:
         log_debug('misc_add_file_cache() Empty dir_str. Exiting')
         return
-    dir_FN = FileName(dir_str)
+    dir_FN = FileNameFactory.create(dir_str)
     log_debug('misc_add_file_cache() Scanning OP "{0}"'.format(dir_FN.getOriginalPath()))
 
     file_list = dir_FN.scanFilesInPathAsFileNameObjects()
@@ -429,7 +432,7 @@ def misc_search_file_cache(dir_str, filename_noext, file_exts):
         #log_debug('misc_search_file_cache() file_Base = "{0}"'.format(file_base))
         if file_base in current_cache_set:
             # log_debug('misc_search_file_cache() Found in cache')
-            return FileName(dir_str).pjoin(file_base)
+            return FileNameFactory.create(dir_str).pjoin(file_base)
 
     return None
 

--- a/tests/executor_test.py
+++ b/tests/executor_test.py
@@ -22,7 +22,7 @@ class Test_executortests(unittest.TestCase):
         set_log_level(LOG_VERB)
         set_use_print(True)
 
-        launcherPath = FileName('path')
+        launcherPath = FileNameFactory.create('path')
 
         settings = {}
         settings['lirc_state'] = True
@@ -44,7 +44,7 @@ class Test_executortests(unittest.TestCase):
         set_log_level(LOG_VERB)
         set_use_print(True)
         
-        launcherPath = FileName('path')
+        launcherPath = FileNameFactory.create('path')
 
         settings = {}
         settings['windows_cd_apppath'] = ''
@@ -67,7 +67,7 @@ class Test_executortests(unittest.TestCase):
         set_log_level(LOG_VERB)
         set_use_print(True)
         
-        launcherPath = FileName('c:\\app\\testcase.bat')
+        launcherPath = FileNameFactory.create('c:\\app\\testcase.bat')
 
         settings = {}
         settings['show_batch_window'] = False
@@ -89,7 +89,7 @@ class Test_executortests(unittest.TestCase):
         set_log_level(LOG_VERB)
         set_use_print(True)
         
-        launcherPath = FileName('c:\\app\\testcase.lnk')
+        launcherPath = FileNameFactory.create('c:\\app\\testcase.lnk')
 
         settings = {}
 
@@ -108,7 +108,7 @@ class Test_executortests(unittest.TestCase):
         set_log_level(LOG_VERB)
         set_use_print(True)
         
-        launcherPath = FileName('c:\\boop\\xbmc.exe')
+        launcherPath = FileNameFactory.create('c:\\boop\\xbmc.exe')
 
         settings = {}
 
@@ -129,7 +129,7 @@ class Test_executortests(unittest.TestCase):
         set_log_level(LOG_VERB)
         set_use_print(True)
 
-        launcherPath = FileName('durp\\apple\\durp')
+        launcherPath = FileNameFactory.create('durp\\apple\\durp')
 
         settings = {}
 
@@ -145,13 +145,13 @@ class Test_executortests(unittest.TestCase):
     def test_when_using_urls_the_correct_web_executor_loads(self):
         
         # arrange
-        launcherPath = FileName('durp\\apple\\durp')
+        launcherPath = FileNameFactory.create('durp\\apple\\durp')
 
         settings = {}
 
         # act
         factory = ExecutorFactory(settings, None)
-        executor = factory.create(FileName('steam://rungameid/'))
+        executor = factory.create(FileNameFactory.create('steam://rungameid/'))
 
         # assert
         actual = executor.__class__.__name__

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -7,6 +7,7 @@ from resources.scrapers import *
 
 from resources.utils import *
 from resources.utils_kodi import *
+from resources.filename import *
 
 class FakeRomSet(RomSet):
 
@@ -50,7 +51,7 @@ class FakeClass():
     def FakeMethod(self, value, launcher):
         self.value = value
 
-class FakeFile(FileName):
+class FakeFile(KodiFileName):
     
     def __init__(self, pathString):
         self.fakeContent  = ''

--- a/tests/romscanners_test.py
+++ b/tests/romscanners_test.py
@@ -144,7 +144,7 @@ class Test_romscannerstests(unittest.TestCase):
         return launcher
 
     @patch('resources.utils_kodi.xbmcgui.DialogProgress.iscanceled')
-    @patch('resources.utils.FileName.recursiveScanFilesInPath')
+    @patch('resources.filename.FileName.recursiveScanFilesInPath')
     def test_when_scanning_with_a_normal_rom_scanner_it_will_go_without_exceptions(self, recursive_scan_mock, progress_canceled_mock):
         
         # arrange
@@ -170,7 +170,7 @@ class Test_romscannerstests(unittest.TestCase):
         romset = FakeRomSet(None, roms)
 
         report_dir = FakeFile('//fake_reports/')
-        addon_dir = FileName('//fake_addon/')
+        addon_dir = FileNameFactory.create('//fake_addon/')
         
         target = RomFolderScanner(report_dir, addon_dir, launcher, romset, settings, scrapers)
         
@@ -181,9 +181,9 @@ class Test_romscannerstests(unittest.TestCase):
         print report_dir.getFakeContent()
         pass
     
-    @patch('resources.utils.FileName.exists', autospec=True)
+    @patch('resources.filename.KodiFileName.exists', autospec=True)
     @patch('resources.utils_kodi.xbmcgui.DialogProgress.iscanceled')
-    @patch('resources.utils.FileName.recursiveScanFilesInPath')
+    @patch('resources.filename.KodiFileName.recursiveScanFilesInPath')
     def test_when_scanning_with_a_normal_rom_scanner_dead_roms_will_be_removed(self, recursive_scan_mock, progress_canceled_mock, file_exists_mock):
         
         # arrange
@@ -220,7 +220,7 @@ class Test_romscannerstests(unittest.TestCase):
         romset = FakeRomSet(None, roms)
 
         report_dir = FakeFile('//fake_reports/')
-        addon_dir = FileName('//fake_addon/')
+        addon_dir = FileNameFactory.create('//fake_addon/')
         
         target = RomFolderScanner(report_dir, addon_dir, launcher, romset, settings, scrapers)
         
@@ -236,9 +236,9 @@ class Test_romscannerstests(unittest.TestCase):
         self.assertEqual(expectedRomCount, actualRomCount)
         print report_dir.getFakeContent()
            
-    @patch('resources.utils.FileName.exists', autospec=True)
+    @patch('resources.filename.KodiFileName.exists', autospec=True)
     @patch('resources.utils_kodi.xbmcgui.DialogProgress.iscanceled')
-    @patch('resources.utils.FileName.recursiveScanFilesInPath')
+    @patch('resources.filename.KodiFileName.recursiveScanFilesInPath')
     def test_when_scanning_with_a_normal_rom_scanner_multidiscs_will_be_put_together(self, recursive_scan_mock, progress_canceled_mock, file_exists_mock):
         
         # arrange
@@ -266,7 +266,7 @@ class Test_romscannerstests(unittest.TestCase):
         romset = FakeRomSet(None, roms)
 
         report_dir = FakeFile('//fake_reports/')
-        addon_dir = FileName('//fake_addon/')
+        addon_dir = FileNameFactory.create('//fake_addon/')
         
         target = RomFolderScanner(report_dir, addon_dir, launcher, romset, settings, scrapers)
         
@@ -288,9 +288,9 @@ class Test_romscannerstests(unittest.TestCase):
 
         self.assertEqual(expectedRomCount, actualRomCount)
     
-    @patch('resources.utils.FileName.exists', autospec=True)
+    @patch('resources.filename.KodiFileName.exists', autospec=True)
     @patch('resources.utils_kodi.xbmcgui.DialogProgress.iscanceled')
-    @patch('resources.utils.FileName.recursiveScanFilesInPath')
+    @patch('resources.filename.KodiFileName.recursiveScanFilesInPath')
     def test_when_scanning_with_a_normal_rom_scanner_existing_items_wont_end_up_double(self, recursive_scan_mock, progress_canceled_mock, file_exists_mock):
         
         # arrange
@@ -322,7 +322,7 @@ class Test_romscannerstests(unittest.TestCase):
         romset = FakeRomSet(None, roms)
 
         report_dir = FakeFile('//fake_reports/')
-        addon_dir = FileName('//fake_addon/')
+        addon_dir = FileNameFactory.create('//fake_addon/')
         
         target = RomFolderScanner(report_dir, addon_dir, launcher, romset, settings, scrapers)
         
@@ -344,9 +344,9 @@ class Test_romscannerstests(unittest.TestCase):
 
         self.assertEqual(expectedRomCount, actualRomCount)
         
-    @patch('resources.utils.FileName.exists', autospec=True)
+    @patch('resources.filename.KodiFileName.exists', autospec=True)
     @patch('resources.utils_kodi.xbmcgui.DialogProgress.iscanceled')
-    @patch('resources.utils.FileName.recursiveScanFilesInPath')
+    @patch('resources.filename.KodiFileName.recursiveScanFilesInPath')
     def test_when_scanning_with_a_normal_rom_scanner_and_bios_roms_must_be_skipped_they_wont_be_added(self, recursive_scan_mock, progress_canceled_mock, file_exists_mock):
         
         # arrange
@@ -370,7 +370,7 @@ class Test_romscannerstests(unittest.TestCase):
         romset = FakeRomSet(None, roms)
 
         report_dir = FakeFile('//fake_reports/')
-        addon_dir = FileName('//fake_addon/')
+        addon_dir = FileNameFactory.create('//fake_addon/')
         
         target = RomFolderScanner(report_dir, addon_dir, launcher, romset, settings, scrapers)
         
@@ -410,7 +410,7 @@ class Test_romscannerstests(unittest.TestCase):
         scrapers = [FakeScraper(scraped_rom)]
 
         report_dir = FakeFile('//fake_reports/')
-        addon_dir = FileName('//fake_addon/')
+        addon_dir = FileNameFactory.create('//fake_addon/')
         
         launcher = self._getFakeLauncherMetaData(LAUNCHER_STEAM, 'Microsoft Windows', '')
         launcher['nointro_xml_file'] = None

--- a/tests/romset_test.py
+++ b/tests/romset_test.py
@@ -17,7 +17,7 @@ class Test_romsettest(unittest.TestCase):
     def test_when_loading_a_normal_rom_list_it_succeeds(self):
         
         # arrange
-        mockPath = FileName('mock')
+        mockPath = FileNameFactory.create('mock')
         target = RomSetFactory(mockPath)
 
         launcherID = 'ut1'
@@ -34,7 +34,7 @@ class Test_romsettest(unittest.TestCase):
     def test_when_loading_a_normal_rom_list_it_returns_the_correct_romset_type(self):
         
         # arrange
-        mockPath = FileName('mock')
+        mockPath = FileNameFactory.create('mock')
         target = RomSetFactory(mockPath)
         launcherID = '1234'
         launchers = {}
@@ -52,7 +52,7 @@ class Test_romsettest(unittest.TestCase):
     def test_when_loading_roms_from_favourites_it_returns_the_correct_romset_type(self):
         
         # arrange
-        mockPath = FileName('mock')
+        mockPath = FileNameFactory.create('mock')
         target = RomSetFactory(mockPath)
         categoryID = VCATEGORY_FAVOURITES_ID
         launcherID = VLAUNCHER_FAVOURITES_ID
@@ -71,7 +71,7 @@ class Test_romsettest(unittest.TestCase):
     def test_when_loading_roms_from_most_played_category_it_returns_the_correct_romset_type(self):
 
         # arrange
-        mockPath = FileName('mock')
+        mockPath = FileNameFactory.create('mock')
         target = RomSetFactory(mockPath)
         categoryID = VCATEGORY_MOST_PLAYED_ID
         launcherID = VLAUNCHER_MOST_PLAYED_ID
@@ -91,7 +91,7 @@ class Test_romsettest(unittest.TestCase):
     def test_when_loading_roms_from_most_played_category_it_returns_the_correct_romset_type(self):
 
         # arrange
-        mockPath = FileName('mock')
+        mockPath = FileNameFactory.create('mock')
         target = RomSetFactory(mockPath)
        
         categoryID = VCATEGORY_RECENT_ID
@@ -110,7 +110,7 @@ class Test_romsettest(unittest.TestCase):
     def test_when_loading_roms_from_a_collection_it_returns_the_correct_romset_type(self):
 
         # arrange
-        mockPath = FileName('mock')
+        mockPath = FileNameFactory.create('mock')
         target = RomSetFactory(mockPath)
         
         categoryID = VCATEGORY_COLLECTIONS_ID
@@ -129,7 +129,7 @@ class Test_romsettest(unittest.TestCase):
     def test_when_loading_roms_from_a_category_it_returns_the_correct_romset_type(self):
 
         # arrange
-        mockPath = FileName('mock')
+        mockPath = FileNameFactory.create('mock')
         target = RomSetFactory(mockPath)
         
         categoryIDs = [VCATEGORY_TITLE_ID, VCATEGORY_YEARS_ID, VCATEGORY_GENRE_ID, VCATEGORY_DEVELOPER_ID, VCATEGORY_CATEGORY_ID]
@@ -150,7 +150,7 @@ class Test_romsettest(unittest.TestCase):
     def test_when_loading_pclone_collection_it_will_return_the_correct_romset_type(self):
         
         # arrange
-        mockPath = FileName('mock')
+        mockPath = FileNameFactory.create('mock')
         target = RomSetFactory(mockPath)
 
         categoryID = VCATEGORY_PCLONES_ID

--- a/tests/scraper_test.py
+++ b/tests/scraper_test.py
@@ -10,6 +10,7 @@ from resources.utils_kodi import *
 from resources.scrapers import *
 from resources.scrap import *
 from resources.assets import *
+from resources.filename import *
 
 class Test_scrapertests(unittest.TestCase):
       
@@ -50,7 +51,7 @@ class Test_scrapertests(unittest.TestCase):
         
         # arrange
         set_use_print(True)
-        addon_dir = FileName('')
+        addon_dir = FileNameFactory.create('')
 
         settings = {}
         settings['scan_metadata_policy'] = 0
@@ -76,7 +77,7 @@ class Test_scrapertests(unittest.TestCase):
         
         # arrange
         set_use_print(True)
-        addon_dir = FileName('')
+        addon_dir = FileNameFactory.create('')
 
         settings = {}
         settings['scan_metadata_policy'] = 0
@@ -108,7 +109,7 @@ class Test_scrapertests(unittest.TestCase):
         
         # arrange
         set_use_print(True)
-        addon_dir = FileName('')
+        addon_dir = FileNameFactory.create('')
 
         settings = {}
         settings['scan_metadata_policy'] = 3 # OnlineScraper only
@@ -138,7 +139,7 @@ class Test_scrapertests(unittest.TestCase):
         
         # arrange
         set_use_print(True)
-        addon_dir = FileName('')
+        addon_dir = FileNameFactory.create('')
 
         settings = {}
         settings['scan_metadata_policy'] = 2 # NFO with Online as decorator
@@ -176,7 +177,7 @@ class Test_scrapertests(unittest.TestCase):
         rom = {}
         rom['m_name'] = ''
 
-        romPath = FileName('/don/el_juan [DUMMY].zip')
+        romPath = FileNameFactory.create('/don/el_juan [DUMMY].zip')
 
         target = CleanTitleScraper(settings, launcher)
 
@@ -191,7 +192,7 @@ class Test_scrapertests(unittest.TestCase):
 
         self.assertEqual(expected, rom['m_name'])
         
-    @patch('resources.utils.FileName.readAllUnicode')
+    @patch('resources.filename.KodiFileName.readAllUnicode')
     def test_when_scraping_with_nfoscraper_it_will_give_the_correct_result(self, mock_filename):
 
          # arrange
@@ -208,7 +209,7 @@ class Test_scrapertests(unittest.TestCase):
         rom = {}
         rom['m_name'] = ''
 
-        romPath = FileName('/don/el_juan [DUMMY].zip')
+        romPath = FileNameFactory.create('/don/el_juan [DUMMY].zip')
 
         target = NfoScraper(settings, launcher)
 
@@ -224,7 +225,7 @@ class Test_scrapertests(unittest.TestCase):
         actual = rom['m_name']
         self.assertEqual(actual, expected)
      
-    @patch('resources.utils.FileName.readXml')
+    @patch('resources.filename.KodiFileName.readXml')
     def test_when_scraping_online_metadata_it_will_give_the_correct_result(self, mock_xmlreader):
         
         # arrange
@@ -246,7 +247,7 @@ class Test_scrapertests(unittest.TestCase):
         rom = {}
         rom['m_name'] = ''
 
-        romPath = FileName('/roms/Pitfall.zip')
+        romPath = FileNameFactory.create('/roms/Pitfall.zip')
 
         target = OnlineMetadataScraper(scraper_obj, settings, launcher)
 
@@ -288,7 +289,7 @@ class Test_scrapertests(unittest.TestCase):
         rom = {}
         rom['m_name'] = ''
 
-        romPath = FileName('/roms/Pitfall.zip')
+        romPath = FileNameFactory.create('/roms/Pitfall.zip')
         asset_kind = ASSET_TITLE
         asset_info = assets_get_info_scheme(asset_kind)
         
@@ -330,7 +331,7 @@ class Test_scrapertests(unittest.TestCase):
         rom = {}
         rom['m_name'] = ''
 
-        romPath = FileName('/roms/Pitfall.zip')
+        romPath = FileNameFactory.create('/roms/Pitfall.zip')
         asset_kind = ASSET_TITLE
         asset_info = assets_get_info_scheme(asset_kind)
         
@@ -356,12 +357,12 @@ class Test_scrapertests(unittest.TestCase):
         self.assertTrue(actualResult)
         mock_imgdownload.assert_called_with(expectedUrl, ANY)
     
-    @patch('resources.utils.FileName.scanFilesInPathAsFileNameObjects')
+    @patch('resources.filename.KodiFileName.scanFilesInPathAsFileNameObjects')
     @patch('resources.scrapers.kodi_update_image_cache')
     def test_when_scraping_local_assets_it_will_give_the_correct_result(self, mock_cache, mock_filescan):
         
         # arrange
-        mock_filescan.return_value = [FileName('x.jpg'),FileName('y.jpg'), FileName('pitfall.jpg'), FileName('donkeykong.jpg')]
+        mock_filescan.return_value = [FileNameFactory.create('x.jpg'),FileNameFactory.create('y.jpg'), FileNameFactory.create('pitfall.jpg'), FileNameFactory.create('donkeykong.jpg')]
 
         settings = {}
         settings['scan_asset_policy'] = 1
@@ -375,7 +376,7 @@ class Test_scrapertests(unittest.TestCase):
         rom = {}
         rom['m_name'] = ''
 
-        romPath = FileName('/roms/Pitfall.zip')
+        romPath = FileNameFactory.create('/roms/Pitfall.zip')
         asset_kind = ASSET_TITLE
         asset_info = assets_get_info_scheme(asset_kind)
 


### PR DESCRIPTION
Moved FileName to its own file and made it abstract to be able to support xbmcvfs but also just normal os operations in cases you run python script outside of kodi (like with tools etc.)
Instead of calling the constructor of FileName directly it is advised to use FileNameFactory.create() so that it can be automatically changed.